### PR TITLE
Fix exception when y_axis_increment is used in line bars

### DIFF
--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -109,9 +109,9 @@ class Gruff::Line < Gruff::Base
     @d.draw(@base_image)
   end
 
-  def normalize
+  def normalize(force=false)
     @maximum_value = [@maximum_value.to_f, @baseline_value.to_f].max
-    super
+    super(force)
     @norm_baseline = (@baseline_value.to_f / @maximum_value.to_f) if @baseline_value
   end
 

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -482,6 +482,17 @@ class TestGruffLine < GruffTestCase
     g.write("test/output/line_marker_label_accuracy.png")
   end
 
+  def test_y_axis_increment
+    g = Gruff::Line.new
+    g.title = "y axis increment"
+
+    g.data('data',  [1,2,3])
+
+    g.y_axis_increment = 1
+
+    g.write("test/output/line_y_axis_increment.png")
+  end
+
 
 private
 


### PR DESCRIPTION
Setting y_axis_increment manually with a line graph will fail with this message:
gruff-0.3.6/lib/gruff/base.rb:687:in `normalize': wrong number of arguments (1 for 0) (ArgumentError)

The problem was a missing argument on normalize in the Line class. I added a test and fixed the code.
