### PR TITLE
Fixed float maths

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -699,8 +699,8 @@ module Gruff
         @d = @d.fill(@marker_color)
         @d = @d.line(@graph_left, y, @graph_right, y)
 
-        marker_label = (BigDecimal(index.to_s) * BigDecimal(@increment.to_s) +
-                        BigDecimal(@minimum_value.to_s)).to_f
+        marker_label = BigDecimal(index.to_s) * BigDecimal(@increment.to_s) +
+                       BigDecimal(@minimum_value.to_s)
 
         unless @hide_line_numbers
           @d.fill = @font_color
@@ -979,9 +979,10 @@ module Gruff
       data_point
     end
 
-    def significant(inc) # :nodoc:
-      return 1.0 if inc == 0 # Keep from going into infinite loop
-      factor = 1.0
+    def significant(i) # :nodoc:
+      return 1.0 if i == 0 # Keep from going into infinite loop
+      inc = BigDecimal(i.to_s)
+      factor = BigDecimal('1.0')
       while (inc < 10)
         inc *= 10
         factor /= 10


### PR DESCRIPTION
I fixed another case of imprecise maths with float numbers (remember https://github.com/topfunky/gruff/pull/15)
This time is in the method `significant` (in `lib/gruff/base.rb`)
The original code

```
def significant(inc) # :nodoc:
  return 1.0 if inc == 0 # Keep from going into infinite loop
  factor = 1.0
  while (inc < 10)
    inc *= 10
    factor /= 10
  end
  while (inc > 100)
    inc /= 10
    factor *= 10
  end
  res = inc.floor * factor
  if (res.to_i.to_f == res)
    res.to_i
  else
    res
  end
end
```

doesn't work fine. Try it in console

```
ruby-1.9.2-p290 :150 > significant 1.2
=> 1.2000000000000002 
```

If you use BigDecimal instead of Float

```
def significant(i) # :nodoc:
  return 1.0 if i == 0 # Keep from going into infinite loop
  inc = BigDecimal(i.to_s)
  factor = BigDecimal('1.0')
  while (inc < 10)
    inc *= 10
    factor /= 10
  end

  while (inc > 100)
    inc /= 10
    factor *= 10
  end

  res = inc.floor * factor
  if (res.to_i.to_f == res)
    res.to_i
  else
    res
  end
end
```

Everything goes right

```
ruby-1.9.2-p290 :174 > r = significant 1.2
=> #<BigDecimal:9f0b7f8,'0.12E1',8(16)> 
ruby-1.9.2-p290 :175 > r.to_f
=> 1.2 
```
