### PR TITLE
Update for Ruby 1.9.3 and hoe gem. Add nil font check.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,16 +3,16 @@ require 'hoe'
 $:.unshift(File.dirname(__FILE__) + "/lib")
 require 'gruff'
 
-Hoe.new('Gruff', Gruff::VERSION) do |p|
-  p.name = "gruff"
-  p.author = "Geoffrey Grosenbach"
-  p.description = "Beautiful graphs for one or multiple datasets. Can be used on websites or in documents."
-  p.email = 'boss@topfunky.com'
-  p.summary = "Beautiful graphs for one or multiple datasets."
-  p.url = "http://nubyonrails.com/pages/gruff"
-  p.clean_globs = ['test/output/*.png']
-  p.changes = p.paragraphs_of('History.txt', 0..1).join("\n\n")
-  p.remote_rdoc_dir = '' # Release to root
+Hoe.spec('Gruff') do
+  self.name = "gruff"
+  self.author = "Geoffrey Grosenbach"
+  self.description = "Beautiful graphs for one or multiple datasets. Can be used on websites or in documents."
+  self.email = 'boss@topfunky.com'
+  self.summary = "Beautiful graphs for one or multiple datasets."
+  self.url = "http://nubyonrails.com/pages/gruff"
+  self.clean_globs = ['test/output/*.png']
+  self.changes = self.paragraphs_of('History.txt', 0..1).join("\n\n")
+  self.remote_rdoc_dir = '' # Release to root
 end
 
 desc "Simple require on packaged files to make sure they are all there"

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1088,7 +1088,7 @@ module Gruff
     # handle.
     def calculate_caps_height(font_size)
       @d.pointsize = font_size
-      @d.font = @font
+      @d.font = @font if @font
       @d.get_type_metrics(@base_image, 'X').height
     end
 
@@ -1098,7 +1098,7 @@ module Gruff
     # scaling will handle.
     def calculate_width(font_size, text)
       @d.pointsize = font_size
-      @d.font = font
+      @d.font = @font if @font
       @d.get_type_metrics(@base_image, text.to_s).width
     end
 

--- a/test/test_mini_bar.rb
+++ b/test/test_mini_bar.rb
@@ -1,5 +1,5 @@
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.expand_path('../gruff_test_case', __FILE__)
 
 class TestMiniBar < GruffTestCase
   

--- a/test/test_mini_pie.rb
+++ b/test/test_mini_pie.rb
@@ -1,5 +1,4 @@
-
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.expand_path('../gruff_test_case', __FILE__)
 
 class TestMiniPie < GruffTestCase
   

--- a/test/test_mini_side_bar.rb
+++ b/test/test_mini_side_bar.rb
@@ -1,5 +1,4 @@
-
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.expand_path('../gruff_test_case', __FILE__)
 
 class TestMiniSideBar < GruffTestCase
     


### PR DESCRIPTION
In order to get this to work on Ruby 1.9.3, change how the load paths were constructed. Add missing checks for empty font values. Use Hoe.spec instead of Hoe.new.
