### PR TITLE
Added marker_shadow_color to allow to draw shadows below marker lines

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -152,6 +152,7 @@ module Gruff
 
     # The color of the auxiliary lines
     attr_accessor :marker_color
+    attr_accessor :marker_shadow_color
 
     # The number of horizontal lines shown for reference
     attr_accessor :marker_count
@@ -332,6 +333,7 @@ module Gruff
           :colors => ['black', 'white'],
           :additional_line_colors => [],
           :marker_color => 'white',
+          :marker_shadow_color => nil,
           :font_color => 'black',
           :background_colors => nil,
           :background_image => nil
@@ -340,6 +342,7 @@ module Gruff
 
       @colors = @theme_options[:colors]
       @marker_color = @theme_options[:marker_color]
+      @marker_shadow_color = @theme_options[:marker_shadow_color]
       @font_color = @theme_options[:font_color] || @marker_color
       @additional_line_colors = @theme_options[:additional_line_colors]
 
@@ -627,6 +630,11 @@ module Gruff
 
         @d = @d.fill(@marker_color)
         @d = @d.line(@graph_left, y, @graph_right, y)
+        #If the user specified a marker shadow color, draw a shadow just below it
+        if not @marker_shadow_color.nil? 
+          @d = @d.fill(@marker_shadow_color)
+          @d = @d.line(@graph_left, y + 1, @graph_right, y + 1)
+        end
 
         marker_label = BigDecimal(index.to_s) * BigDecimal(@increment.to_s) +
             BigDecimal(@minimum_value.to_s)


### PR DESCRIPTION
Added marker_shadow_color to base chart.

If the marker_shadow_color is present, the marker_line will have a small shadow cast below it with the specified color, this is useful to create a depth effect.
