### PR TITLE
convert nils to zero

### DIFF
--- a/lib/gruff/bar_conversion.rb
+++ b/lib/gruff/bar_conversion.rb
@@ -18,6 +18,8 @@ class Gruff::BarConversion
   attr_writer :spread
 
   def get_left_y_right_y_scaled(data_point, result)
+	data_point = 0 if data_point.nil?
+
     case @mode
     when 1 then # Case one
                 # minimum value >= 0 ( only positiv values )


### PR DESCRIPTION
When an array is built up like this:

x = []
x[2] = 33
x[7] = 1

the values which haven't been explicitly set are nil and so bits of the method fails. This line just sets any nils to zero.