### PR TITLE
Legends as tables and better y_increment algorithm

### DIFF
--- a/Base
+++ b/Base
@@ -1,0 +1,173 @@
+module Gruff
+  class Base
+    attr_accessor :legend_as_table
+    
+    def guesstimate_y_increment
+      #Was derived from Toon Krijthe's reponse @ http://stackoverflow.com/questions/326679/choosing-an-attractive-linear-scale-for-a-graphs-y-axis
+      self.marker_count ||= 8
+      
+      values = @data.map{|d| d[1]}.flatten
+      unless values.present? || values.uniq.length == 1
+        return self.y_axis_increment = nil 
+      end
+      
+      values.sort!
+      min, max, avg = values.first, values.last, (values.inject(0){|sum,x| sum += x } / values.length) 
+      range = max - min
+      float_tick_size = range / (self.marker_count - 1)
+      pow10x = 10 ** (Math.log10(float_tick_size) - 1).ceil
+      
+      self.y_axis_increment = ((float_tick_size / pow10x).ceil * pow10x)
+    end
+    
+    def initialize_ivars
+      # Internal for calculations
+      @raw_columns = 800.0
+      @raw_rows = 800.0 * (@rows/@columns)
+      @column_count = 0
+      @marker_count = nil
+      @maximum_value = @minimum_value = nil
+      @has_data = false
+      @data = Array.new
+      @labels = Hash.new
+      @labels_seen = Hash.new
+      @sort = false
+      @title = nil
+
+      @scale = @columns / @raw_columns
+
+      vera_font_path = File.expand_path('Vera.ttf', ENV['MAGICK_FONT_PATH'])
+      @font = File.exists?(vera_font_path) ? vera_font_path : nil
+
+      @marker_font_size = 21.0
+      @legend_font_size = 20.0
+      @title_font_size = 36.0
+
+      @top_margin = @bottom_margin = @left_margin = @right_margin = DEFAULT_MARGIN
+      @legend_margin = LEGEND_MARGIN
+      @title_margin = TITLE_MARGIN
+
+      @legend_box_size = 20.0
+
+      @no_data_message = 'No Data'
+
+      @hide_line_markers = @hide_legend = @hide_title = @hide_line_numbers = @legend_at_bottom = @show_labels_for_bar_values = false
+      @center_labels_over_point = true
+      @has_left_labels = false
+      @label_stagger_height = 0
+      @label_max_size = 0
+      @label_truncation_style = :absolute
+
+      @additional_line_values = []
+      @additional_line_colors = []
+      @theme_options = {}
+
+      @x_axis_label = @y_axis_label = nil
+      @y_axis_increment = nil
+      @stacked = nil
+      @norm_data = nil
+      
+      
+      #This is the only modification here
+      @legend_as_table = false
+    end
+    
+    protected
+    def draw_legend
+      return if @hide_legend
+
+      @legend_labels = @data.collect { |item| item[DATA_LABEL_INDEX] }
+      legend_square_width = @legend_box_size # small square with color of this item
+      
+      #CUSTOM
+      if @legend_as_table
+        @min_label_length = @legend_labels.dup.map{|label| @d.get_type_metrics(@base_image, label.to_s).width + legend_square_width * 1.7}.sort.pop
+      else
+        @min_label_length = nil
+      end
+      
+      # May fix legend drawing problem at small sizes
+      @d.font = @font if @font
+      @d.pointsize = @legend_font_size
+
+      label_widths = [[]] # Used to calculate line wrap
+      @legend_labels.each do |label|
+        metrics = @d.get_type_metrics(@base_image, label.to_s)
+        label_width = metrics.width + legend_square_width * 2.7
+        label_widths.last.push @min_label_length || label_width
+
+        if sum(label_widths.last) > (@raw_columns * 0.9)
+          label_widths.push [label_widths.last.pop]
+        end
+      end
+      
+      #CUSTOM
+      if @legend_as_table
+        @starting_x_offset = label_widths.dup.map{|widths| center(sum(widths)) }.sort.shift
+        if label_widths.last.length != label_widths.first.length
+          @special = true
+          @special_count = label_widths.last.length
+        else
+          @special = false
+          @special_count = 0
+        end
+      end
+      
+      current_x_offset = center(sum(label_widths.first))
+      current_y_offset = @legend_at_bottom ? @graph_height + title_margin : (@hide_title ?
+          @top_margin + title_margin :
+          @top_margin + title_margin + @title_caps_height)
+
+      @legend_labels.each_with_index do |legend_label, index|
+        if @special && index + 1 > @legend_labels.length - @special_count
+          current_x_offset = @starting_x_offset
+        end
+        # Draw label
+        @d.fill = @font_color
+        @d.font = @font if @font
+        @d.pointsize = scale_fontsize(@legend_font_size)
+        @d.stroke('transparent')
+        @d.font_weight = NormalWeight
+        @d.gravity = WestGravity
+        @d = @d.annotate_scaled(@base_image,
+                                @raw_columns, 1.0,
+                                current_x_offset + (legend_square_width * 1.7) + 50, current_y_offset,
+                                legend_label.to_s, @scale)
+
+        # Now draw box with color of this dataset
+        @d = @d.stroke('transparent')
+        @d = @d.fill @data[index][DATA_COLOR_INDEX]
+        @d = @d.rectangle(current_x_offset + 50,
+                          current_y_offset - legend_square_width / 2.0,
+                          current_x_offset + 50 + legend_square_width,
+                          current_y_offset + legend_square_width / 2.0)
+
+        @d.pointsize = @legend_font_size
+        metrics = @d.get_type_metrics(@base_image, legend_label.to_s)
+        current_string_offset = metrics.width + (legend_square_width * 2.7)
+        
+        # Handle wrapping
+        label_widths.first.shift
+        if label_widths.first.empty?
+          debug { @d.line 0.0, current_y_offset, @raw_columns, current_y_offset }
+
+          label_widths.shift
+          unless label_widths.empty?
+            current_x_offset = center(sum(label_widths.first))
+          end
+          line_height = [@legend_caps_height, legend_square_width].max + (@legend_as_table ? 2 : legend_margin) #CUSTOM
+          if label_widths.length > 0
+            # Wrap to next line and shrink available graph dimensions
+            current_y_offset += line_height
+            @graph_top += line_height
+            @graph_height = @graph_bottom - @graph_top
+          end
+        else
+          #custom
+          current_x_offset += @min_label_length || current_string_offset
+        end
+      end
+      @color_index = 0
+    end
+  end
+end


### PR DESCRIPTION
All modifications are to the Gruff::Base class

Added new attr_accessor for `legend_as_table`(bool, defined in `initialize_ivars`) for defining the table layout as columns instead of placing to fit.

Also calling `.guesstimate_y_increment` on an instance of the Gruff::Base will auto populate `y_axis_increment` and optionally `marker_count` (depending on if it's defined at the time).  The algorithm handles a wide range of values and defaults to having 8 markers on a graph.

I tried to make the changes to `draw_legend` as simple as possible and flag them as appropriate.  You should see a "#CUSTOM" next to/above anything I've modified.

guesstimate_y_increment was derived from Toon Krijthe's reponse @ http://stackoverflow.com/questions/326679/choosing-an-attractive-linear-scale-for-a-graphs-y-axis
