### PR TITLE
initialize bezier curve to start at it's first datum, not at origin.

### DIFF
--- a/lib/gruff/bezier.rb
+++ b/lib/gruff/bezier.rb
@@ -18,8 +18,8 @@ class Gruff::Bezier < Gruff::Base
         new_y = @graph_top + (@graph_height - data_point * @graph_height)
 
         if index == 0 && RUBY_PLATFORM != 'java'
-          poly_points << @graph_left
-          poly_points << @graph_bottom - 1
+          poly_points << new_x
+          poly_points << new_y
         end
 
         poly_points << new_x


### PR DESCRIPTION
I've modified Bezier to initialize the curves from the first datum rather than zero (or more strictly, the calculated value that is stored in @graph_left and @graph_bottom). Previously, the first datum for each curve was lost, and the curves skewed by being dragged harshly down to the origin.