### PR TITLE
test/scatter.rb line 28, switched x_values and y_values argument order.

### DIFF
--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -25,7 +25,7 @@ class TestGruffScatter < Test::Unit::TestCase
     g.title = 'Many Datapoint Graph Test'
     y_values = (0..50).map { rand(100) }
     x_values = (0..50).map { rand(100) }
-    g.data('many points', y_values, x_values)
+    g.data('many points', x_values, y_values)
 
     # Default theme
     g.write('test/output/scatter_many.png')


### PR DESCRIPTION
Fixed the order of `x_values` and `y_values` in `test_scatter.rb`, line 28.