### PR TITLE
Allow stacked bar chart segment spacing to be adjusted

### DIFF
--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -7,6 +7,9 @@ class Gruff::StackedBar < Gruff::Base
 
     # Spacing factor applied between bars
     attr_accessor :bar_spacing
+
+    # Number of pixels between bar segments
+    attr_accessor :segment_spacing
     
     # Draws a bar graph, but multiple sets are stacked on top of each other.
     def draw
@@ -18,6 +21,7 @@ class Gruff::StackedBar < Gruff::Base
       #
       # Columns sit stacked.
       @bar_spacing ||= 0.9
+      @segment_spacing ||= 1
       @bar_width = @graph_width / @column_count.to_f
       padding = (@bar_width * (1 - @bar_spacing)) / 2
     
@@ -38,9 +42,9 @@ class Gruff::StackedBar < Gruff::Base
           left_x = @graph_left + (@bar_width * point_index) + padding
           left_y = @graph_top + (@graph_height -
                                  data_point * @graph_height - 
-                                 height[point_index]) + 1
+                                 height[point_index]) + @segment_spacing
           right_x = left_x + @bar_width * @bar_spacing
-          right_y = @graph_top + @graph_height - height[point_index] - 1
+          right_y = @graph_top + @graph_height - height[point_index] - @segment_spacing
           
           # update the total height of the current stacked bar
           height[point_index] += (data_point * @graph_height ) 


### PR DESCRIPTION
By default, Gruff puts 1px spacing between each segment of a stacked bar chart. This commits allows that number to be adjusted.

Here's the default spacing:

![stacked_bar_keynote_1px](https://cloud.githubusercontent.com/assets/3478/3245524/23b35ae8-f173-11e3-8868-c1d6e1d228bc.png)

And here's the same graph with the segment spacing set to 0:

![stacked_bar_keynote_0px](https://cloud.githubusercontent.com/assets/3478/3245531/42a0bb76-f173-11e3-80f2-48f6895b64a4.png)
