### PR TITLE
Move 'deg2rad' from monkeypatch to private method

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1123,6 +1123,11 @@ module Gruff
       @d.get_type_metrics(@base_image, text.to_s).width
     end
 
+    # Used for degree => radian conversions
+    def deg2rad(angle)
+      angle * (Math::PI/180.0)
+    end
+
   end # Gruff::Base
 
   class IncorrectNumberOfDatasetsException < StandardError;

--- a/lib/gruff/net.rb
+++ b/lib/gruff/net.rb
@@ -111,8 +111,8 @@ class Gruff::Net < Gruff::Base
     r_offset = 1.1
     x_offset = center_x # + 15 # The label points need to be tweaked slightly
     y_offset = center_y # + 0  # This one doesn't though
-    x = x_offset + (radius * r_offset * Math.sin(angle.deg2rad))
-    y = y_offset - (radius * r_offset * Math.cos(angle.deg2rad))
+    x = x_offset + (radius * r_offset * Math.sin(deg2rad(angle)))
+    y = y_offset - (radius * r_offset * Math.cos(deg2rad(angle)))
 
     # Draw label
     @d.fill = @marker_color
@@ -125,14 +125,3 @@ class Gruff::Net < Gruff::Base
   end
 
 end
-
-# # This method is already in Float
-# class Float
-#   # Used for degree => radian conversions
-#   def deg2rad
-#     self * (Math::PI/180.0)
-#   end
-# end
-
-
-

--- a/lib/gruff/pie.rb
+++ b/lib/gruff/pie.rb
@@ -91,8 +91,8 @@ private
     y_offset = center_y  # This one doesn't though
     radius_offset = (radius + r_offset)
     ellipse_factor = radius_offset * TEXT_OFFSET_PERCENTAGE
-    x = x_offset + ((radius_offset + ellipse_factor) * Math.cos(angle.deg2rad))
-    y = y_offset + (radius_offset * Math.sin(angle.deg2rad))
+    x = x_offset + ((radius_offset + ellipse_factor) * Math.cos(deg2rad(angle)))
+    y = y_offset + (radius_offset * Math.sin(deg2rad(angle)))
     
     # Draw label
     @d.fill = @font_color
@@ -114,11 +114,3 @@ private
   end
 
 end
-
-class Float
-  # Used for degree => radian conversions
-  def deg2rad
-    self * (Math::PI/180.0)
-  end
-end
-


### PR DESCRIPTION
In Ruby 2.1.2, we were encountering issues where `angle` was a BigDecimal, and `deg2rad` was defined as a method on Float, so we were getting an undefined method error. This commit moves `deg2rad` into a private method on Gruff::Base that takes an argument that can be any numeric type.

Similar issue: https://github.com/topfunky/gruff/issues/97
