### PR TITLE
Change the way RMagick is required by the base class.

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'RMagick'
+require 'rmagick'
 require 'bigdecimal'
 
 require File.dirname(__FILE__) + '/deprecated'


### PR DESCRIPTION
The old form is deprecated, and throws the following warning whenever Gruff is used:

    [DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead