### PR TITLE
Add test-unit as a dev dependency.

### DIFF
--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -25,5 +25,6 @@ Gem::Specification.new do |s|
     s.add_dependency 'rmagick'
   end
   s.add_development_dependency('rake')
+  s.add_development_dependency('test-unit')
   s.license = 'MIT'
 end


### PR DESCRIPTION
Ruby >= 2.2 no longer comes with test-unit built in.