### PR TITLE
Fix rmagick deprecation warning by requiring rmagic instead of Rmagick.

### DIFF
--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -20,9 +20,9 @@ Gem::Specification.new do |s|
   s.specification_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION
   if defined? JRUBY_VERSION
     s.platform = 'java'
-    s.add_dependency 'rmagick4j'
+    s.add_dependency 'rmagick4j', ">= 0.3.9"
   else
-    s.add_dependency 'rmagick'
+    s.add_dependency 'rmagick', ">= 2.13.4"
   end
   s.add_development_dependency('rake')
   s.license = 'MIT'

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'RMagick'
+require 'rmagick'
 require 'bigdecimal'
 
 require File.dirname(__FILE__) + '/deprecated'


### PR DESCRIPTION
Gruff now needs rmagic version >= 2.13.4, since that's when rmagick.rb
was introduced.

Tested with:
* ruby-2.2.1
* ruby-1.9.3
* jruby-1.7.19

If the ability to use older version of rmagick is desired, that can be done by something along the lines of:

    begin
      require 'rmagic'
    rescue LoadError
      require "RMagick'
    end
