### PR TITLE
add yield in to_blob if a block is given. 

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -444,6 +444,7 @@ module Gruff
       draw
       @base_image.to_blob do
         self.format = fileformat
+        yield self if block_given?
       end
     end
 


### PR DESCRIPTION
This allows for all RMagick's to_blob customizations, like quality and CompressionType:

``` ruby
blob = chart.to_blob('JPEG') do |info|
   info.quality = 1
end
```
