### PR TITLE
Rubocop: Remove trailing blank lines

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -480,20 +480,6 @@ Layout/Tab:
     - 'lib/gruff/bar_conversion.rb'
     - 'lib/gruff/side_stacked_bar.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: final_newline, final_blank_line
-Layout/TrailingEmptyLines:
-  Exclude:
-    - 'Rakefile'
-    - 'lib/gruff/photo_bar.rb'
-    - 'lib/gruff/themes.rb'
-    - 'test/test_bar.rb'
-    - 'test/test_dot.rb'
-    - 'test/test_side_bar.rb'
-    - 'test/test_sidestacked_bar.rb'
-
 # Offense count: 1
 Lint/AmbiguousBlockAssociation:
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -215,4 +215,3 @@ end
 def wrap(string, indent = 0)
   string.scan(/\S.{0,72}\S(?=\s|$)|\S+/).join("\n" + ' ' * indent)
 end
-

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -97,4 +97,3 @@ protected
   end
 
 end
-

--- a/lib/gruff/themes.rb
+++ b/lib/gruff/themes.rb
@@ -99,4 +99,3 @@ module Gruff
 
   end
 end
-

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -502,4 +502,3 @@ class TestGruffBar < GruffTestCase
     g
   end
 end
-

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -260,4 +260,3 @@ protected
   end
 
 end
-

--- a/test/test_side_bar.rb
+++ b/test/test_side_bar.rb
@@ -53,4 +53,3 @@ class TestGruffSideBar < GruffTestCase
   end
 
 end
-

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -102,4 +102,3 @@ protected
   end
 
 end
-


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/TrailingEmptyLines --auto-correct