### PR TITLE
Rubocop: Remove blank lines around method body

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -144,19 +144,6 @@ Layout/EmptyLinesAroundBlockBody:
 Layout/EmptyLinesAroundClassBody:
   Enabled: false
 
-# Offense count: 10
-# Cop supports --auto-correct.
-Layout/EmptyLinesAroundMethodBody:
-  Exclude:
-    - 'lib/gruff/line.rb'
-    - 'lib/gruff/scatter.rb'
-    - 'lib/gruff/side_bar.rb'
-    - 'test/test_line.rb'
-    - 'test/test_sidestacked_bar.rb'
-    - 'test/test_spider.rb'
-    - 'test/test_stacked_area.rb'
-    - 'test/test_stacked_bar.rb'
-
 # Offense count: 15
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -157,7 +157,6 @@ class Gruff::Line < Gruff::Base
       @minimum_x_value = (x_data_point < @minimum_x_value) ?
           x_data_point : @minimum_x_value
     end
-
   end
 
   def draw_reference_line(reference_line, left, right, top, bottom)
@@ -268,7 +267,6 @@ class Gruff::Line < Gruff::Base
   end
 
   def setup_data
-
     # Deal with horizontal reference line values that exceed the existing minimum & maximum values.
     possible_maximums = [@maximum_value.to_f]
     possible_minimums = [@minimum_value.to_f]
@@ -309,7 +307,6 @@ class Gruff::Line < Gruff::Base
         @norm_data[index] << norm_x_data_points
       end
     end
-
   end
 
   def sort_norm_data

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -168,7 +168,6 @@ class Gruff::Scatter < Gruff::Base
   # g.data('bitter_melon', [3,5,6], [6,7,8], '#000000')
   #
   def data(name, x_data_points=[], y_data_points=[], color=nil)
-
     raise ArgumentError, 'Data Points contain nil Value!' if x_data_points.include?(nil) || y_data_points.include?(nil)
     raise ArgumentError, 'x_data_points is empty!' if x_data_points.empty?
     raise ArgumentError, 'y_data_points is empty!' if y_data_points.empty?

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -78,7 +78,6 @@ class Gruff::SideBar < Gruff::Base
 
   # Instead of base class version, draws vertical background lines and label
   def draw_line_markers
-
     return if @hide_line_markers
 
     @d = @d.stroke_antialias false

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -546,7 +546,6 @@ class TestGruffLine < GruffTestCase
   end
 
   def test_multiple_reference_lines
-
     g = Gruff::Line.new
     g.title = 'Line Chart with Multiple Reference Lines'
 

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -18,7 +18,6 @@ class TestGruffSideStackedBar < GruffTestCase
         1 => '5/15',
         2 => '5/24'
       }
-
   end
 
   def test_bar_graph

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -120,7 +120,6 @@ class TestGruffSpider < GruffTestCase
      g.data(data[0], data[1])
     end
     g.write("test/output/spider_no_axes.png")
-
   end
 
   def test_no_print

--- a/test/test_stacked_area.rb
+++ b/test/test_stacked_area.rb
@@ -15,7 +15,6 @@ class TestGruffStackedArea < GruffTestCase
         1 => '5/15',
         2 => '5/24'
       }
-
   end
 
   def test_area_graph

--- a/test/test_stacked_bar.rb
+++ b/test/test_stacked_bar.rb
@@ -15,7 +15,6 @@ class TestGruffStackedBar < GruffTestCase
         1 => '5/15',
         2 => '5/24'
       }
-
   end
 
   def test_bar_graph


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/EmptyLinesAroundMethodBody --auto-correct