### PR TITLE
Rubocop: Convert tab to space indentation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -417,13 +417,6 @@ Layout/SpaceInsideRangeLiteral:
   Exclude:
     - 'lib/gruff/base.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: IndentationWidth.
-Layout/Tab:
-  Exclude:
-    - 'lib/gruff/bar_conversion.rb'
-
 # Offense count: 1
 Lint/AmbiguousBlockAssociation:
   Exclude:

--- a/lib/gruff/bar_conversion.rb
+++ b/lib/gruff/bar_conversion.rb
@@ -1,13 +1,13 @@
 ##
 # Original Author: David Stokar
 #
-#	This class perfoms the y coordinats conversion for the bar class.
+#   This class perfoms the y coordinats conversion for the bar class.
 #
-#	There are three cases:
+#   There are three cases:
 #
 #   1. Bars all go from zero in positive direction
-#		2. Bars all go from zero to negative direction
-#		3. Bars either go from zero to positive or from zero to negative
+#   2. Bars all go from zero to negative direction
+#   3. Bars either go from zero to positive or from zero to negative
 #
 class Gruff::BarConversion
   attr_writer :mode


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/Tab --auto-correct