### PR TITLE
Rubocop: Remove blank lines around block

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -117,26 +117,6 @@ Layout/EmptyLineAfterMagicComment:
   Exclude:
     - 'gruff.gemspec'
 
-# Offense count: 21
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, no_empty_lines
-Layout/EmptyLinesAroundBlockBody:
-  Exclude:
-    - 'lib/gruff/area.rb'
-    - 'lib/gruff/bar.rb'
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/dot.rb'
-    - 'lib/gruff/line.rb'
-    - 'lib/gruff/mini/legend.rb'
-    - 'lib/gruff/net.rb'
-    - 'lib/gruff/photo_bar.rb'
-    - 'lib/gruff/scatter.rb'
-    - 'lib/gruff/side_bar.rb'
-    - 'lib/gruff/side_stacked_bar.rb'
-    - 'lib/gruff/stacked_area.rb'
-    - 'lib/gruff/stacked_bar.rb'
-
 # Offense count: 82
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/lib/gruff/area.rb
+++ b/lib/gruff/area.rb
@@ -41,7 +41,6 @@ class Gruff::Area < Gruff::Base
       poly_points << @graph_bottom - 1
 
       @d = @d.polyline(*poly_points)
-
     end
 
     @d.draw(@base_image)

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -70,7 +70,6 @@ protected
 
     # iterate over all normalised data
     @norm_data.each_with_index do |data_row, row_index|
-
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|
         # Use incremented x and scaled y
         # x
@@ -96,7 +95,6 @@ protected
           draw_value_label(left_x + (right_x - left_x)/2, conv[0]-30, val.commify, true)
         end
       end
-
     end
 
     # Draw the last label if requested

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -761,7 +761,6 @@ module Gruff
           @top_margin + title_margin + @title_caps_height)
 
       @legend_labels.each_with_index do |legend_label, index|
-
         # Draw label
         @d.fill = @font_color
         @d.font = @font if @font

--- a/lib/gruff/dot.rb
+++ b/lib/gruff/dot.rb
@@ -42,7 +42,6 @@ class Gruff::Dot < Gruff::Base
 
         draw_label(y_pos, point_index)
       end
-
     end
 
     @d.draw(@base_image)

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -288,12 +288,10 @@ class Gruff::Line < Gruff::Base
     super(force)
 
     @reference_lines.each_value do |curr_reference_line|
-
       # We only care about horizontal markers ... for normalization.
       # Vertical markers won't have a :value, they will have an :index
 
       curr_reference_line[:norm_value] = ((curr_reference_line[:value].to_f - @minimum_value) / @spread.to_f) if (curr_reference_line.key?(:value))
-
     end
 
     #normalize the x data if it is specified

--- a/lib/gruff/mini/legend.rb
+++ b/lib/gruff/mini/legend.rb
@@ -70,7 +70,6 @@ module Gruff
         debug { @d.line 0.0, current_y_offset, @raw_columns, current_y_offset }
 
         @legend_labels.each_with_index do |legend_label, index|
-
           # Draw label
           @d.fill = @font_color
           @d.font = @font if @font

--- a/lib/gruff/net.rb
+++ b/lib/gruff/net.rb
@@ -69,7 +69,6 @@ class Gruff::Net < Gruff::Base
 
         @d = @d.circle(start_x, start_y, start_x - circle_radius, start_y) unless @hide_dots
       end
-
     end
 
     @d.draw(@base_image)

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -47,7 +47,6 @@ class Gruff::PhotoBar < Gruff::Base
     @bar_width = @norm_data[0][DATA_COLOR_INDEX].columns
 
     @norm_data.each_with_index do |data_row, row_index|
-
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|
         data_point = 0 if data_point.nil?
         # Use incremented x and scaled y
@@ -69,7 +68,6 @@ class Gruff::PhotoBar < Gruff::Base
         label_center = @graph_left + (@data.length * @bar_width * point_index) + (@data.length * @bar_width / 2.0)
         draw_label(label_center, point_index)
       end
-
     end
 
     @d.draw(@base_image)

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -255,7 +255,6 @@ protected
 
     # Draw vertical line markers and annotate with numbers
     (0..@marker_x_count).each do |index|
-
       # TODO Fix the vertical lines, and enable them by default. Not pretty when they don't match up with top y-axis line
       if @enable_vertical_line_markers
         x = @graph_left + @graph_width - index.to_f * @increment_x_scaled

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -39,7 +39,6 @@ class Gruff::SideBar < Gruff::Base
       @d = @d.fill data_row[DATA_COLOR_INDEX]
 
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|
-
         # Using the original calcs from the stacked bar chart
         # to get the difference between
         # part of the bart chart we wish to stack.
@@ -70,7 +69,6 @@ class Gruff::SideBar < Gruff::Base
           draw_value_label(right_x+40, (@graph_top + (((row_index+point_index+1) * @bar_width) - (@bar_width / 2)))-12, val.commify, true)
         end
       end
-
     end
 
     @d.draw(@base_image)
@@ -91,7 +89,6 @@ class Gruff::SideBar < Gruff::Base
     # TODO Round maximum marker value to a round number like 100, 0.1, 0.5, etc.
     increment = significant(@spread.to_f / number_of_lines)
     (0..number_of_lines).each do |index|
-
       line_diff = (@graph_right - @graph_left) / number_of_lines
       x = @graph_right - (line_diff * index) - 1
       @d = @d.line(x, @graph_bottom, x, @graph_top)

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -39,7 +39,6 @@ class Gruff::SideStackedBar < Gruff::SideBar
     end
     @norm_data.each_with_index do |data_row, row_index|
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|
-
         ## using the original calcs from the stacked bar chart to get the difference between
         ## part of the bart chart we wish to stack.
         temp1 = @graph_left + (@graph_width -
@@ -74,7 +73,6 @@ class Gruff::SideStackedBar < Gruff::SideBar
         label_center = @graph_top + (@bar_width * point_index) + (@bar_width * @bar_spacing / 2.0)
         draw_label(label_center, point_index)
       end
-
     end
     if @show_labels_for_bar_values
       label_values.each_with_index do |data, i|

--- a/lib/gruff/stacked_area.rb
+++ b/lib/gruff/stacked_area.rb
@@ -36,7 +36,6 @@ class Gruff::StackedArea < Gruff::Base
         data_points << new_y
 
         draw_label(new_x, index)
-
       end
 
       if prev_data_points
@@ -57,7 +56,6 @@ class Gruff::StackedArea < Gruff::Base
         poly_points << data_points[1]
       end
       @d = @d.polyline(*poly_points)
-
     end
 
     @d.draw(@base_image)

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -50,9 +50,7 @@ class Gruff::StackedBar < Gruff::Base
         height[point_index] += (data_point * @graph_height )
 
         @d = @d.rectangle(left_x, left_y, right_x, right_y)
-
       end
-
     end
 
     @d.draw(@base_image)


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/EmptyLinesAroundBlockBody --auto-correct