### PR TITLE
Rubocop: Add space after comma

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -301,17 +301,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/gruff/line.rb'
     - 'lib/gruff/net.rb'
 
-# Offense count: 13
-# Cop supports --auto-correct.
-Layout/SpaceAfterComma:
-  Exclude:
-    - 'Rakefile'
-    - 'test/test_accumulator_bar.rb'
-    - 'test/test_bezier.rb'
-    - 'test/test_dot.rb'
-    - 'test/test_net.rb'
-    - 'test/test_scatter.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleInsidePipes.

--- a/Rakefile
+++ b/Rakefile
@@ -39,7 +39,7 @@ New in version #{milestone_name}:
 
 #{(categories.keys & grouped_issues.keys).map do |cat|
     "#{cat}:\n
-#{grouped_issues[cat].map { |i| wrap(%Q{* Issue ##{i['number']} #{i['title']}},2) }.join("\n")}
+#{grouped_issues[cat].map { |i| wrap(%Q{* Issue ##{i['number']} #{i['title']}}, 2) }.join("\n")}
     "
   end.join("\n")}
 You can find a complete list of issues here:

--- a/test/test_accumulator_bar.rb
+++ b/test/test_accumulator_bar.rb
@@ -42,8 +42,8 @@ class TestGruffAccumulatorBar < GruffTestCase
   def test_too_many_args
     assert_raises(Gruff::IncorrectNumberOfDatasetsException) {
       g = Gruff::AccumulatorBar.new
-      g.data 'First', [1,1,1]
-      g.data 'Too Many', [1,1,1]
+      g.data 'First', [1, 1, 1]
+      g.data 'Too Many', [1, 1, 1]
       g.write('test/output/_SHOULD_NOT_ACTUALLY_BE_WRITTEN.png')
     }
   end

--- a/test/test_bezier.rb
+++ b/test/test_bezier.rb
@@ -25,7 +25,7 @@ class TestBezier < GruffTestCase
 
   def test_bezier_3
     g = Gruff::Bezier.new
-    g.data 'Series 3', [100,300,200,250]
+    g.data 'Series 3', [100, 300, 200, 250]
     g.minimum_value = 0
     g.write("test/output/bezier_3.png")
   end

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -138,7 +138,7 @@ class TestGruffDot < GruffTestCase
       0 => '1',
       1 => '2'
     }
-    g.data('one', [1,1])
+    g.data('one', [1, 1])
 
     g.write('test/output/dot_one_value.png')
   end

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -164,7 +164,7 @@ class TestGruffNet < GruffTestCase
     g = Gruff::Net.new(400)
     g.title = "All Zeros"
 
-    g.data(:gus, [0,0,0,0])
+    g.data(:gus, [0, 0, 0, 0])
 
     # Default theme
     g.write("test/output/net_no_data_other.png")

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -56,7 +56,7 @@ class TestGruffScatter < Minitest::Test
     g.enable_vertical_line_markers = true
     g.marker_x_count = 50 # One label every 2 days
     g.x_axis_label_format = lambda do |value|
-      DateTime.strptime(value.to_i.to_s,'%s').strftime('%d.%m.%Y')
+      DateTime.strptime(value.to_i.to_s, '%s').strftime('%d.%m.%Y')
     end
     g.y_axis_increment = 1
 


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/SpaceAfterComma --auto-correct