### PR TITLE
Rubocop: Fix extra spaces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -138,15 +138,6 @@ Layout/EmptyLinesAroundModuleBody:
     - 'lib/gruff/mini/side_bar.rb'
     - 'lib/gruff/themes.rb'
 
-# Offense count: 3
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, AllowBeforeTrailingComments, ForceEqualSignAlignment.
-Layout/ExtraSpacing:
-  Exclude:
-    - 'lib/gruff/bullet.rb'
-    - 'lib/gruff/pie.rb'
-    - 'lib/gruff/spider.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -69,7 +69,7 @@ class Gruff::Bullet < Gruff::Base
     [:high, :low].each_with_index do |indicator, index|
       next unless @options.has_key?(indicator)
       @d = @d.fill @colors[index + 1]
-      indicator_width_x  = @graph_left + @graph_width * (@options[indicator] / @maximum_value)
+      indicator_width_x = @graph_left + @graph_width * (@options[indicator] / @maximum_value)
       @d = @d.rectangle(@graph_left, 0, indicator_width_x, @graph_height)
     end
 

--- a/lib/gruff/pie.rb
+++ b/lib/gruff/pie.rb
@@ -163,7 +163,7 @@ class Gruff::Pie < Gruff::Base
 
   def process_label_for(slice)
     if slice.percentage >= hide_labels_less_than
-      x, y  = label_coordinates_for slice
+      x, y = label_coordinates_for slice
 
       @d = draw_label(x, y, slice.label)
     end

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -60,7 +60,7 @@ private
   end
 
   def draw_label(center_x, center_y, angle, radius, amount)
-    r_offset = 50      # The distance out from the center of the pie to get point
+    r_offset = 50            # The distance out from the center of the pie to get point
     x_offset = center_x      # The label points need to be tweaked slightly
     y_offset = center_y + 0  # This one doesn't though
     x = x_offset + ((radius + r_offset) * Math.cos(angle))


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/ExtraSpacing --auto-correct