### PR TITLE
Remove the upper limit from the required Ruby version

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,6 +21,13 @@ Gemspec/OrderedDependencies:
   Exclude:
     - 'gruff.gemspec'
 
+# Offense count: 1
+# Configuration parameters: Include.
+# Include: **/*.gemspec
+Gemspec/RequiredRubyVersion:
+  Exclude:
+    - 'gruff.gemspec'
+
 # Offense count: 14
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -23,10 +23,10 @@ Gem::Specification.new do |s|
   if defined? JRUBY_VERSION
     s.platform = 'java'
     s.add_dependency 'rmagick4j'
-    s.required_ruby_version = ['>= 1.9.3', '< 3']
+    s.required_ruby_version = '>= 1.9.3'
   else
     s.add_dependency 'rmagick'
-    s.required_ruby_version = ['>= 2.3', '< 3']
+    s.required_ruby_version = '>= 2.3'
     s.add_development_dependency 'rubocop', '~> 0.80.1'
   end
   s.add_development_dependency('rake')


### PR DESCRIPTION
Because Ruby 3.0 is scheduled to be released this year.