### PR TITLE
Adjust the lower limit of required_ruby_version

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -7,13 +7,6 @@
 # versions of RuboCop, may require this file to be generated again.
 
 # Offense count: 1
-# Configuration parameters: Include.
-# Include: **/*.gemspec
-Gemspec/DuplicatedAssignment:
-  Exclude:
-    - 'gruff.gemspec'
-
-# Offense count: 1
 # Cop supports --auto-correct.
 # Configuration parameters: TreatCommentsAsGroupSeparators, Include.
 # Include: **/*.gemspec

--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -23,12 +23,12 @@ Gem::Specification.new do |s|
   if defined? JRUBY_VERSION
     s.platform = 'java'
     s.add_dependency 'rmagick4j'
-    s.required_ruby_version = '>= 1.9.3'
   else
     s.add_dependency 'rmagick'
-    s.required_ruby_version = '>= 2.3'
     s.add_development_dependency 'rubocop', '~> 0.80.1'
   end
+  s.required_ruby_version = '>= 1.9.3'
+
   s.add_development_dependency('rake')
   s.add_development_dependency('minitest-reporters')
 end


### PR DESCRIPTION
If you use the old rmagick, it might work with ruby 1.9…