### PR TITLE
Rubocop: Remove leading blank lines

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -218,20 +218,6 @@ Layout/LeadingCommentSpace:
     - 'test/test_scatter.rb'
     - 'test/test_sidestacked_bar.rb'
 
-# Offense count: 9
-# Cop supports --auto-correct.
-Layout/LeadingEmptyLines:
-  Exclude:
-    - 'lib/gruff/area.rb'
-    - 'lib/gruff/deprecated.rb'
-    - 'lib/gruff/scene.rb'
-    - 'lib/gruff/spider.rb'
-    - 'lib/gruff/stacked_area.rb'
-    - 'lib/gruff/stacked_bar.rb'
-    - 'lib/gruff/stacked_mixin.rb'
-    - 'test/test_mini_bar.rb'
-    - 'test/test_side_bar.rb'
-
 # Offense count: 24
 # Cop supports --auto-correct.
 Layout/MultilineArrayLineBreaks:

--- a/lib/gruff/area.rb
+++ b/lib/gruff/area.rb
@@ -1,4 +1,3 @@
-
 require File.dirname(__FILE__) + '/base'
 
 class Gruff::Area < Gruff::Base

--- a/lib/gruff/deprecated.rb
+++ b/lib/gruff/deprecated.rb
@@ -1,4 +1,3 @@
-
 ##
 # A mixin for methods that need to be deleted or have been
 # replaced by cleaner code.

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -1,4 +1,3 @@
-
 require "observer"
 require File.dirname(__FILE__) + '/base'
 

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -1,4 +1,3 @@
-
 require File.dirname(__FILE__) + '/base'
 
 # Experimental!!! See also the Net graph.

--- a/lib/gruff/stacked_area.rb
+++ b/lib/gruff/stacked_area.rb
@@ -1,4 +1,3 @@
-
 require File.dirname(__FILE__) + '/base'
 require File.dirname(__FILE__) + '/stacked_mixin'
 

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -1,4 +1,3 @@
-
 require File.dirname(__FILE__) + '/base'
 require File.dirname(__FILE__) + '/stacked_mixin'
 

--- a/lib/gruff/stacked_mixin.rb
+++ b/lib/gruff/stacked_mixin.rb
@@ -1,4 +1,3 @@
-
 module Gruff::Base::StackedMixin
   # Used by StackedBar and child classes.
   #

--- a/test/test_mini_bar.rb
+++ b/test/test_mini_bar.rb
@@ -1,4 +1,3 @@
-
 require File.expand_path('../gruff_test_case', __FILE__)
 
 class TestMiniBar < GruffTestCase

--- a/test/test_side_bar.rb
+++ b/test/test_side_bar.rb
@@ -1,4 +1,3 @@
-
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffSideBar < GruffTestCase


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/LeadingEmptyLines --auto-correct