### PR TITLE
Rubocop: Fix indentation of assignment

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,13 +49,6 @@ Layout/ArgumentAlignment:
     - 'lib/gruff/scatter.rb'
     - 'lib/gruff/spider.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: IndentationWidth.
-Layout/AssignmentIndentation:
-  Exclude:
-    - 'lib/gruff/base.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyleAlignWith.

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1028,7 +1028,7 @@ module Gruff
     # correctly in the drawn graph.
     def sort_norm_data
       @norm_data =
-          @norm_data.sort_by { |a| -a[DATA_VALUES_INDEX].inject(0) { |sum, num| sum + num.to_f } }
+        @norm_data.sort_by { |a| -a[DATA_VALUES_INDEX].inject(0) { |sum, num| sum + num.to_f } }
     end
 
     # Used by StackedBar and child classes.


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/AssignmentIndentation --auto-correct