### PR TITLE
Rubocop: Remove spaces inside parens

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -313,19 +313,6 @@ Layout/SpaceInsideHashLiteralBraces:
     - 'test/test_line.rb'
     - 'test/test_side_bar.rb'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceInsideParens:
-  Exclude:
-    - 'lib/gruff/bar.rb'
-    - 'lib/gruff/mini/legend.rb'
-    - 'lib/gruff/spider.rb'
-    - 'lib/gruff/stacked_bar.rb'
-    - 'test/test_net.rb'
-    - 'test/test_scene.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/SpaceInsideRangeLiteral:

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -77,7 +77,7 @@ protected
         right_x = left_x + @bar_width * @bar_spacing
         # y
         conv = []
-        conversion.get_left_y_right_y_scaled( data_point, conv )
+        conversion.get_left_y_right_y_scaled(data_point, conv)
 
         # create new bar
         @d = @d.fill data_row[DATA_COLOR_INDEX]

--- a/lib/gruff/mini/legend.rb
+++ b/lib/gruff/mini/legend.rb
@@ -77,10 +77,10 @@ module Gruff
           @d.stroke = 'transparent'
           @d.font_weight = Magick::NormalWeight
           @d.gravity = Magick::WestGravity
-          @d = @d.annotate_scaled( @base_image,
-                                   @raw_columns, 1.0,
-                                   current_x_offset + (legend_square_width * 1.7), current_y_offset,
-                                   truncate_legend_label(legend_label), @scale)
+          @d = @d.annotate_scaled(@base_image,
+                                  @raw_columns, 1.0,
+                                  current_x_offset + (legend_square_width * 1.7), current_y_offset,
+                                  truncate_legend_label(legend_label), @scale)
 
           # Now draw box with color of this dataset
           @d = @d.stroke 'transparent'

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -72,7 +72,7 @@ private
     @d.stroke = 'transparent'
     @d.font_weight = BoldWeight
     @d.gravity = CenterGravity
-    @d.annotate_scaled( @base_image,
+    @d.annotate_scaled(@base_image,
                       0, 0,
                       x, y,
                       amount, @scale)

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -46,7 +46,7 @@ class Gruff::StackedBar < Gruff::Base
         right_y = @graph_top + @graph_height - height[point_index] - @segment_spacing
 
         # update the total height of the current stacked bar
-        height[point_index] += (data_point * @graph_height )
+        height[point_index] += (data_point * @graph_height)
 
         @d = @d.rectangle(left_x, left_y, right_x, right_y)
       end

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -104,7 +104,7 @@ class TestGruffNet < GruffTestCase
   def test_similar_high_end_values
     g = Gruff::Net.new
     g.title = "Similar High End Values Test"
-    g.data('similar points', %w(29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828).collect {|i| i.to_f} )
+    g.data('similar points', %w(29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828).collect {|i| i.to_f})
 
     # Default theme
     g.write("test/output/net_similar_high_end_values.png")

--- a/test/test_scene.rb
+++ b/test/test_scene.rb
@@ -87,7 +87,7 @@ class TestGruffScene < GruffTestCase
 private
 
   def setup_scene
-    g = Gruff::Scene.new("500x100", File.expand_path("../assets/city_scene", File.dirname(__FILE__)) )
+    g = Gruff::Scene.new("500x100", File.expand_path("../assets/city_scene", File.dirname(__FILE__)))
     g.layers = %w(background haze sky clouds)
     g.weather_group = %w(clouds)
     g.time_group = %w(background sky)


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/SpaceInsideParens --auto-correct