### PR TITLE
Rubocop: Add space after block parameter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -257,14 +257,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/gruff/line.rb'
     - 'lib/gruff/net.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleInsidePipes.
-# SupportedStylesInsidePipes: space, no_space
-Layout/SpaceAroundBlockParameters:
-  Exclude:
-    - 'Rakefile'
-
 # Offense count: 37
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/Rakefile
+++ b/Rakefile
@@ -189,7 +189,7 @@ def get_github_issues
   issues = YAML.load(res.body).sort_by { |i| i['number'] }
   milestone_name = issues[0] ? issues[0]['milestone']['title'] : "No issues for milestone #{milestone}"
   milestone_description = issues[0] ? issues[0]['milestone']['description'] : "No issues for milestone #{milestone}"
-  milestone_description = milestone_description.split("\r\n").map {|l|wrap l}.join("\r\n")
+  milestone_description = milestone_description.split("\r\n").map {|l| wrap l}.join("\r\n")
   categories = {
     'Features' => 'feature', 'Bugfixes' => 'bug', 'Support' => 'support',
     'Documentation' => 'documentation', 'Pull requests' => nil,


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/SpaceAroundBlockParameters --auto-correct