### PR TITLE
Rubocop: Use each_key instead of keys.each

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -727,13 +727,6 @@ Style/GuardClause:
     - 'lib/gruff/scatter.rb'
     - 'lib/gruff/side_bar.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/HashEachMethods:
-  Exclude:
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/stacked_mixin.rb'
-
 # Offense count: 141
 # Cop supports --auto-correct.
 # Configuration parameters: UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1045,7 +1045,7 @@ module Gruff
       end
 
       # @maximum_value = 0
-      max_hash.keys.each do |key|
+      max_hash.each_key do |key|
         @maximum_value = max_hash[key] if max_hash[key] > @maximum_value
       end
       @minimum_value = 0

--- a/lib/gruff/stacked_mixin.rb
+++ b/lib/gruff/stacked_mixin.rb
@@ -14,7 +14,7 @@ module Gruff::Base::StackedMixin
     end
 
     # @maximum_value = 0
-    max_hash.keys.each do |key|
+    max_hash.each_key do |key|
       @maximum_value = max_hash[key] if max_hash[key] > @maximum_value
     end
     @minimum_value = 0


### PR DESCRIPTION
$ bundle exec rubocop --only Style/HashEachMethods --auto-correct