### PR TITLE
Rubocop: Remove ‘then’ from if statement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -832,12 +832,6 @@ Style/MissingRespondToMissing:
   Exclude:
     - 'lib/gruff/scene.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/MultilineIfThen:
-  Exclude:
-    - 'lib/gruff/bar.rb'
-
 # Offense count: 13
 Style/MultilineTernaryOperator:
   Exclude:

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -52,12 +52,12 @@ protected
     conversion.graph_top = @graph_top
 
     # Set up the right mode [1,2,3] see BarConversion for further explanation
-    if @minimum_value >= 0 then
+    if @minimum_value >= 0
       # all bars go from zero to positiv
       conversion.mode = 1
     else
       # all bars go from 0 to negativ
-      if @maximum_value <= 0 then
+      if @maximum_value <= 0
         conversion.mode = 2
       else
         # bars either go from zero to negativ or to positiv


### PR DESCRIPTION
$ bundle exec rubocop --only Style/MultilineIfThen --auto-correct