### PR TITLE
Rubocop: Use ternary operator instead of oneline if statement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -919,12 +919,6 @@ Style/NumericPredicate:
     - 'lib/gruff/side_bar.rb'
     - 'lib/gruff/stacked_bar.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/OneLineConditional:
-  Exclude:
-    - 'lib/gruff/base.rb'
-
 # Offense count: 2
 # Configuration parameters: SuspiciousParamNames.
 # SuspiciousParamNames: options, opts, args, params, parameters

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -814,7 +814,7 @@ module Gruff
       @d.font = @title_font || @font if @title_font || @font
       @d.stroke('transparent')
       @d.pointsize = scale_fontsize(@title_font_size)
-      @d.font_weight = if @bold_title then BoldWeight else NormalWeight end
+      @d.font_weight = @bold_title ? BoldWeight : NormalWeight
       @d.gravity = NorthGravity
       @d = @d.annotate_scaled(@base_image,
                               @raw_columns, 1.0,


### PR DESCRIPTION
$ bundle exec rubocop --only Style/OneLineConditional --auto-correct