### PR TITLE
Rubocop: Avoid parallel assignment for readability

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -921,15 +921,6 @@ Style/OptionHash:
     - 'lib/gruff/bullet.rb'
     - 'test/test_pie.rb'
 
-# Offense count: 6
-# Cop supports --auto-correct.
-Style/ParallelAssignment:
-  Exclude:
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/line.rb'
-    - 'test/gruff_test_case.rb'
-    - 'test/image_compare.rb'
-
 # Offense count: 8
 # Cop supports --auto-correct.
 # Configuration parameters: AllowSafeAssignment, AllowInMultilineConditions.

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -540,9 +540,9 @@ module Gruff
           calculate_caps_height(@legend_font_size)
 
       if @hide_line_markers
-        (@graph_left,
-            @graph_right_margin,
-            @graph_bottom_margin) = [@left_margin, @right_margin, @bottom_margin]
+        @graph_left = @left_margin
+        @graph_right_margin = @right_margin
+        @graph_bottom_margin = @bottom_margin
       else
         if @has_left_labels
           longest_left_label_width = calculate_width(@marker_font_size,

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -131,7 +131,8 @@ class Gruff::Line < Gruff::Base
     raise ArgumentError, 'x_data_points is nil!' if x_data_points.length == 0
 
     if x_data_points.all? { |p| p.is_a?(Array) && p.size == 2 }
-      x_data_points, y_data_points = x_data_points.map { |p| p[0] }, x_data_points.map { |p| p[1] }
+      y_data_points = x_data_points.map { |p| p[1] }
+      x_data_points = x_data_points.map { |p| p[0] }
     end
 
     raise ArgumentError, 'x_data_points.length != y_data_points.length!' if x_data_points.length != y_data_points.length
@@ -259,7 +260,8 @@ class Gruff::Line < Gruff::Base
           @d = DotRenderers.renderer(@dot_style).render(@d, new_x, new_y, circle_radius)
         end
 
-        prev_x, prev_y = new_x, new_y
+        prev_x = new_x
+        prev_y = new_y
       end
     end
 

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -117,7 +117,8 @@ class GruffTestCase < Minitest::Test
   #   setup_basic_graph Gruff::Pie, 400
   #
   def setup_basic_graph(*args)
-    klass, size = Gruff::Bar, 400
+    klass = Gruff::Bar
+    size = 400
     # Allow args to be klass, size or just klass or just size.
     #
     # TODO Refactor
@@ -134,7 +135,8 @@ class GruffTestCase < Minitest::Test
         klass = args[0]
       end
     when 2
-      klass, size = args[0], args[1]
+      klass = args[0]
+      size = args[1]
     end
 
     g = klass.new(size)

--- a/test/image_compare.rb
+++ b/test/image_compare.rb
@@ -37,7 +37,8 @@ class ImageCompare
       return false
     end
 
-    x, y = diff.map { |xy| xy[0] }, diff.map { |xy| xy[1] }
+    x = diff.map { |xy| xy[0] }
+    y = diff.map { |xy| xy[1] }
     (1..2).each do |i|
       images.each do |image|
         image.rect(x.min - i, y.min - i, x.max + i, y.max + i, ChunkyPNG::Color.rgb(255, 0, 0))


### PR DESCRIPTION
$ bundle exec rubocop --only Style/ParallelAssignment --auto-correct