### PR TITLE
Rubocop: Fix indentation of access modifiers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,3 +5,6 @@ AllCops:
     Exclude:
         - 'vendor/bundle/**/*'
         - 'rails_generators/gruff/**/*'
+
+Layout/AccessModifierIndentation:
+  EnforcedStyle: outdent

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,25 +21,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'gruff.gemspec'
 
-# Offense count: 14
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: outdent, indent
-Layout/AccessModifierIndentation:
-  Exclude:
-    - 'lib/gruff/bar.rb'
-    - 'lib/gruff/photo_bar.rb'
-    - 'lib/gruff/scatter.rb'
-    - 'lib/gruff/scene.rb'
-    - 'lib/gruff/spider.rb'
-    - 'test/test_area.rb'
-    - 'test/test_dot.rb'
-    - 'test/test_net.rb'
-    - 'test/test_pie.rb'
-    - 'test/test_scene.rb'
-    - 'test/test_sidestacked_bar.rb'
-    - 'test/test_spider.rb'
-
 # Offense count: 6
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -447,7 +447,7 @@ module Gruff
       end
     end
 
-    protected
+  protected
 
     # Overridden by subclasses to do the actual plotting of the graph.
     #
@@ -1061,7 +1061,7 @@ module Gruff
       end
     end
 
-    private
+  private
 
     # Takes a block and draws it if DEBUG is true.
     #

--- a/lib/gruff/dot.rb
+++ b/lib/gruff/dot.rb
@@ -47,7 +47,7 @@ class Gruff::Dot < Gruff::Base
     @d.draw(@base_image)
   end
 
-  protected
+protected
 
   # Instead of base class version, draws vertical background lines and label
   def draw_line_markers

--- a/lib/gruff/net.rb
+++ b/lib/gruff/net.rb
@@ -99,7 +99,7 @@ class Gruff::Net < Gruff::Base
     end
   end
 
-  private
+private
 
   def draw_label(center_x, center_y, angle, radius, amount)
     r_offset = 1.1

--- a/lib/gruff/pie.rb
+++ b/lib/gruff/pie.rb
@@ -78,7 +78,7 @@ class Gruff::Pie < Gruff::Base
     trigger_final_draw
   end
 
-  private
+private
 
   def slices
     @slices ||= begin

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -16,7 +16,7 @@ class Gruff::SideBar < Gruff::Base
     draw_bars
   end
 
-  protected
+protected
 
   def draw_bars
     # Setup spacing.

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -20,7 +20,7 @@ class Gruff::SideStackedBar < Gruff::SideBar
     super
   end
 
-  protected
+protected
 
   def draw_bars
     # Setup spacing.

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -79,7 +79,7 @@ class GruffTestCase < Minitest::Test
     assert true
   end
 
-  protected
+protected
 
   # Generate graphs at several sizes.
   #

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -464,7 +464,7 @@ class TestGruffBar < GruffTestCase
     g.write('test/output/bar_marker_shadow.png')
   end
 
-  protected
+protected
 
   def setup_basic_graph(size=800)
     g = Gruff::Bar.new(size)

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -590,7 +590,7 @@ class TestGruffLine < GruffTestCase
     # assert_match(/no encode delegate for this image format .*\.webp/, $!.message)
   end
 
-  private
+private
 
   # TODO Reset data after each theme
   def line_graph_with_themes(size=nil)

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -175,7 +175,7 @@ protected
       @data.each { |data_array| data_array << options[:label] }
     end
 
-    private
+  private
 
     def slice_class
       CustomLabeledSlice

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -240,7 +240,7 @@ class TestGruffScatter < Minitest::Test
     g.write('test/output/scatter_no_labels.png')
   end
 
-  protected
+protected
 
   def setup_basic_graph(size=800)
     g = Gruff::Scatter.new(size)


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/AccessModifierIndentation --auto-correct