### PR TITLE
Rubocop: Remove empty comments

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -63,13 +63,6 @@ Layout/CommentIndentation:
     - 'test/test_sidestacked_bar.rb'
     - 'test/test_spider.rb'
 
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: AllowBorderComment, AllowMarginComment.
-Layout/EmptyComment:
-  Exclude:
-    - 'lib/gruff/themes.rb'
-
 # Offense count: 12
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterGuardClause:

--- a/lib/gruff/themes.rb
+++ b/lib/gruff/themes.rb
@@ -85,12 +85,12 @@ module Gruff
     # A greyscale theme
     GREYSCALE = {
       :colors => [
-        '#282828', #
-        '#383838', #
-        '#686868', #
-        '#989898', #
-        '#c8c8c8', #
-        '#e8e8e8', #
+        '#282828',
+        '#383838',
+        '#686868',
+        '#989898',
+        '#c8c8c8',
+        '#e8e8e8',
       ],
       :marker_color => '#aea9a9', # Grey
       :font_color => 'black',


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/EmptyComment --auto-correct