### PR TITLE
Rubocop: Add space around ‘=‘ of default parameter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -231,13 +231,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/gruff/line.rb'
     - 'lib/gruff/net.rb'
 
-# Offense count: 37
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: space, no_space
-Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: false
-
 # Offense count: 49
 # Cop supports --auto-correct.
 # Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -216,7 +216,7 @@ module Gruff
     #
     # Looks for Bitstream Vera as the default font. Expects an environment var
     # of MAGICK_FONT_PATH to be set. (Uses RMagick's default font otherwise.)
-    def initialize(target_width=DEFAULT_TARGET_WIDTH)
+    def initialize(target_width = DEFAULT_TARGET_WIDTH)
       if Numeric === target_width
         @columns = target_width.to_f
         @rows = target_width.to_f * 0.75
@@ -326,7 +326,7 @@ module Gruff
     #
     # Example:
     #  replace_colors ['#cc99cc', '#d9e043', '#34d8a2']
-    def replace_colors(color_list=[])
+    def replace_colors(color_list = [])
       @colors = color_list
       @color_index = 0
     end
@@ -405,7 +405,7 @@ module Gruff
     #
     # Example:
     #   data("Bart S.", [95, 45, 78, 89, 88, 76], '#ffcc00')
-    def data(name, data_points=[], color=nil)
+    def data(name, data_points = [], color = nil)
       data_points = Array(data_points) # make sure it's an array
       @data << [name, data_points, color]
                                        # Set column count if this is larger than previous counts
@@ -434,13 +434,13 @@ module Gruff
     #
     # Example:
     #   write('graphs/my_pretty_graph.png')
-    def write(filename='graph.png')
+    def write(filename = 'graph.png')
       draw
       @base_image.write(filename)
     end
 
     # Return the graph as a rendered binary blob.
-    def to_blob(fileformat='PNG')
+    def to_blob(fileformat = 'PNG')
       draw
       @base_image.to_blob do
         self.format = fileformat
@@ -500,7 +500,7 @@ module Gruff
     end
 
     # Make copy of data with values scaled between 0-100
-    def normalize(force=false)
+    def normalize(force = false)
       if @norm_data.nil? || force
         @norm_data = []
         return unless @has_data
@@ -870,7 +870,7 @@ module Gruff
     end
 
     # Draws the data value over the data point in bar graphs
-    def draw_value_label(x_offset, y_offset, data_point, bar_value=false)
+    def draw_value_label(x_offset, y_offset, data_point, bar_value = false)
       return if @hide_line_markers && !bar_value
 
       #y_offset = @graph_bottom + LABEL_MARGIN
@@ -1180,7 +1180,7 @@ end # Magick
 
 class String
   #Taken from http://codesnippets.joyent.com/posts/show/330
-  def commify(delimiter=',')
+  def commify(delimiter = ',')
     self.gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{delimiter}")
   end
 end

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -4,7 +4,7 @@ require 'gruff/themes'
 # http://en.wikipedia.org/wiki/Bullet_graph
 class Gruff::Bullet < Gruff::Base
 
-  def initialize(target_width="400x40")
+  def initialize(target_width = "400x40")
     if not Numeric === target_width
       geometric_width, geometric_height = target_width.split('x')
       @columns = geometric_width.to_f
@@ -21,7 +21,7 @@ class Gruff::Bullet < Gruff::Base
     @title_font_size = 20
   end
 
-  def data(value, maximum_value, options={})
+  def data(value, maximum_value, options = {})
     @value = value.to_f
     @maximum_value = maximum_value.to_f
     @options = options

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -127,7 +127,7 @@ class Gruff::Line < Gruff::Base
   #   In this example the lables are drawn at x positions 2, 4, and 6:
   #   g.labels = {0 => '2003', 2 => '2004', 4 => '2005', 6 => '2006'}
   #   The 0 => '2003' label will be ignored since it is outside the chart range.
-  def dataxy(name, x_data_points=[], y_data_points=[], color=nil)
+  def dataxy(name, x_data_points = [], y_data_points = [], color = nil)
     raise ArgumentError, 'x_data_points is nil!' if x_data_points.length == 0
 
     if x_data_points.all? { |p| p.is_a?(Array) && p.size == 2 }
@@ -286,7 +286,7 @@ class Gruff::Line < Gruff::Base
     super
   end
 
-  def normalize(force=false)
+  def normalize(force = false)
     super(force)
 
     @reference_lines.each_value do |curr_reference_line|

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -167,7 +167,7 @@ class Gruff::Scatter < Gruff::Base
   # g.data('oranges', [1,1,1], [2,3,4])
   # g.data('bitter_melon', [3,5,6], [6,7,8], '#000000')
   #
-  def data(name, x_data_points=[], y_data_points=[], color=nil)
+  def data(name, x_data_points = [], y_data_points = [], color = nil)
     raise ArgumentError, 'Data Points contain nil Value!' if x_data_points.include?(nil) || y_data_points.include?(nil)
     raise ArgumentError, 'x_data_points is empty!' if x_data_points.empty?
     raise ArgumentError, 'y_data_points is empty!' if y_data_points.empty?
@@ -198,7 +198,7 @@ protected
     @x_spread = @x_spread > 0 ? @x_spread : 1
   end
 
-  def normalize(force=nil)
+  def normalize(force = nil)
     if @norm_data.nil? || force
       @norm_data = []
       return unless @has_data

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -114,7 +114,7 @@ protected
   ##
   # Draw on the Y axis instead of the X
 
-  def draw_label(y_offset, index, label=nil)
+  def draw_label(y_offset, index, label = nil)
     if !@labels[index].nil? && @labels_seen[index].nil?
       lbl = (@use_data_label) ? label : @labels[index]
       @d.fill = @font_color

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -84,7 +84,7 @@ protected
     @d.draw(@base_image)
   end
 
-  def larger_than_max?(data_point, index=0)
+  def larger_than_max?(data_point, index = 0)
     max(data_point, index) > @maximum_value
   end
 

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -16,7 +16,7 @@ Minitest::Reporters.use!
 class Gruff::Base
   alias :write_org :write
 
-  def write(filename='graph.png')
+  def write(filename = 'graph.png')
     basefilename = File.basename(filename).split('.')[0..-2].join('.')
     extension = filename.slice(/\.[^\.]*$/)
     testfilename = File.join(TEST_OUTPUT_DIR, basefilename) + extension
@@ -89,7 +89,7 @@ protected
   #     g.data('students', [1, 2, 3, 4])
   #   end
   #
-  def graph_sized(filename, sizes=['', 400])
+  def graph_sized(filename, sizes = ['', 400])
     class_name = self.class.name.gsub(/^TestGruff/, '')
     Array(sizes).each do |size|
       g = instance_eval("Gruff::#{class_name}.new #{size}")

--- a/test/test_area.rb
+++ b/test/test_area.rb
@@ -121,7 +121,7 @@ class TestGruffArea < GruffTestCase
 
 protected
 
-  def setup_basic_graph(size=800)
+  def setup_basic_graph(size = 800)
     g = Gruff::Area.new(size)
     g.title = "My Graph Title"
     g.labels = @sample_labels

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -466,7 +466,7 @@ class TestGruffBar < GruffTestCase
 
 protected
 
-  def setup_basic_graph(size=800)
+  def setup_basic_graph(size = 800)
     g = Gruff::Bar.new(size)
     g.title = 'My Bar Graph'
     g.labels = {
@@ -481,7 +481,7 @@ protected
     g
   end
 
-  def setup_long_labelled_graph(size=500)
+  def setup_long_labelled_graph(size = 500)
     g = Gruff::Bar.new(size)
     g.title = 'A Graph for All Seasons'
     g.labels = {

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -237,7 +237,7 @@ class TestGruffDot < GruffTestCase
 
 protected
 
-  def setup_basic_graph(size=800)
+  def setup_basic_graph(size = 800)
     g = Gruff::Dot.new(size)
     g.title = 'My Dot Graph'
     g.labels = {

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -593,7 +593,7 @@ class TestGruffLine < GruffTestCase
 private
 
   # TODO Reset data after each theme
-  def line_graph_with_themes(size=nil)
+  def line_graph_with_themes(size = nil)
     g = Gruff::Line.new(size)
     g.title = "Multi-Line Graph Test #{size}"
     g.labels = @labels
@@ -635,7 +635,7 @@ private
     g.write("test/output/line_theme_odeo_#{size}.png")
   end
 
-  def setup_pos_neg(size=800)
+  def setup_pos_neg(size = 800)
     g = Gruff::Line.new(size)
     g.title = 'Pos/Neg Line Graph Test'
     g.labels = {
@@ -649,7 +649,7 @@ private
     g
   end
 
-  def setup_all_neg(size=800)
+  def setup_all_neg(size = 800)
     g = Gruff::Line.new(size)
     g.title = 'All Neg Line Graph Test'
     g.labels = {

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -215,7 +215,7 @@ class TestGruffNet < GruffTestCase
 
 protected
 
-  def setup_basic_graph(size=800)
+  def setup_basic_graph(size = 800)
     g = Gruff::Net.new(size)
     g.title = "My Graph Title"
     g.labels = @sample_labels

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -158,7 +158,7 @@ class TestGruffPie < GruffTestCase
 
 protected
 
-  def setup_basic_graph(size=800)
+  def setup_basic_graph(size = 800)
     g = Gruff::Pie.new(size)
     g.title = "My Graph Title"
     @datasets.each do |data|

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -242,7 +242,7 @@ class TestGruffScatter < Minitest::Test
 
 protected
 
-  def setup_basic_graph(size=800)
+  def setup_basic_graph(size = 800)
     g = Gruff::Scatter.new(size)
     g.title = 'Rad Graph'
     @datasets.each do |data|
@@ -251,7 +251,7 @@ protected
     g
   end
 
-  def setup_pos_neg(size=800)
+  def setup_pos_neg(size = 800)
     g = Gruff::Scatter.new(size)
     g.title = 'Pos/Neg Scatter Graph Test'
     g.data(:apples, [-1, 0, 4, -4], [-5, -1, 3, 4])
@@ -259,7 +259,7 @@ protected
     g
   end
 
-  def setup_all_neg(size=800)
+  def setup_all_neg(size = 800)
     g = Gruff::Scatter.new(size)
     g.title = 'Neg Scatter Graph Test'
     g.data(:apples, [-1, -1, -4, -4], [-5, -1, -3, -4])

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -89,7 +89,7 @@ class TestGruffSideStackedBar < GruffTestCase
 
 protected
 
-  def setup_basic_graph(size=800)
+  def setup_basic_graph(size = 800)
     g = Gruff::SideStackedBar.new(size)
     g.title = "My Graph Title"
     g.labels = @sample_labels

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -213,7 +213,7 @@ class TestGruffSpider < GruffTestCase
 
 protected
 
-  def setup_basic_graph(size=800, max = 20)
+  def setup_basic_graph(size = 800, max = 20)
     g = Gruff::Spider.new(max, size)
     g.title = "My Graph Title"
     @datasets.each do |data|


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/SpaceAroundEqualsInParameterDefault --auto-correct