### PR TITLE
Rubocop: Use Integer instead of Fixnum

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -323,12 +323,6 @@ Lint/SuppressedException:
     - 'test/test_line.rb'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Lint/UnifiedInteger:
-  Exclude:
-    - 'test/gruff_test_case.rb'
-
-# Offense count: 1
 Lint/UnreachableCode:
   Exclude:
     - 'lib/gruff/photo_bar.rb'

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -125,7 +125,7 @@ protected
     case args.length
     when 1
       case args[0]
-      when Fixnum
+      when Integer
         size = args[0]
         klass = eval("Gruff::#{self.class.name.gsub(/^TestGruff/, '')}")
       when String


### PR DESCRIPTION
$ bundle exec rubocop --only Lint/UnifiedInteger --auto-correct