### PR TITLE
Rubocop: Add space around operators

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -231,13 +231,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/gruff/line.rb'
     - 'lib/gruff/net.rb'
 
-# Offense count: 49
-# Cop supports --auto-correct.
-# Configuration parameters: AllowForAlignment, EnforcedStyleForExponentOperator.
-# SupportedStylesForExponentOperator: space, no_space
-Layout/SpaceAroundOperators:
-  Enabled: false
-
 # Offense count: 79
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.

--- a/Rakefile
+++ b/Rakefile
@@ -131,14 +131,14 @@ task :stats do
   years = counts_per_month.keys
   puts '    ' + years.map { |year| '%-12s' % year }.join
   (0..20).each do |l|
-    print (l % 10 == 0) ? '%4d' % ((20-l) * 100) : '    '
+    print (l % 10 == 0) ? '%4d' % ((20 - l) * 100) : '    '
     years.each do |year|
       (1..12).each do |month|
         count = counts_per_month[year][month]
         if [year, month] == [Date.today.year, Date.today.month]
           count *= (Date.new(Date.today.year, Date.today.month, -1).day.to_f / Date.today.day).to_i
         end
-        print count > ((20-l) * 100) ? '*' : ' '
+        print count > ((20 - l) * 100) ? '*' : ' '
       end
     end
     puts

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -64,7 +64,7 @@ protected
         conversion.mode = 3
         conversion.spread = @spread
         conversion.minimum_value = @minimum_value
-        conversion.zero = -@minimum_value/@spread
+        conversion.zero = -@minimum_value / @spread
       end
     end
 
@@ -92,7 +92,7 @@ protected
         draw_label(label_center - (@center_labels_over_point ? @bar_width / 2.0 : 0.0), point_index)
         if @show_labels_for_bar_values
           val = (@label_formatting || '%.2f') % @norm_data[row_index][3][point_index]
-          draw_value_label(left_x + (right_x - left_x)/2, conv[0]-30, val.commify, true)
+          draw_value_label(left_x + (right_x - left_x) / 2, conv[0] - 30, val.commify, true)
         end
       end
     end

--- a/lib/gruff/bar_conversion.rb
+++ b/lib/gruff/bar_conversion.rb
@@ -21,21 +21,21 @@ class Gruff::BarConversion
     case @mode
     when 1 then # Case one
                 # minimum value >= 0 ( only positiv values )
-      result[0] = @graph_top + @graph_height*(1 - data_point) + 1
+      result[0] = @graph_top + @graph_height * (1 - data_point) + 1
       result[1] = @graph_top + @graph_height - 1
     when 2 then # Case two
                 # only negativ values
       result[0] = @graph_top + 1
-      result[1] = @graph_top + @graph_height*(1 - data_point) - 1
+      result[1] = @graph_top + @graph_height * (1 - data_point) - 1
     when 3 then # Case three
                 # positiv and negativ values
-      val = data_point-@minimum_value/@spread
+      val = data_point - @minimum_value / @spread
       if data_point >= @zero
-        result[0] = @graph_top + @graph_height*(1 - (val-@zero)) + 1
-        result[1] = @graph_top + @graph_height*(1 - @zero) - 1
+        result[0] = @graph_top + @graph_height * (1 - (val - @zero)) + 1
+        result[1] = @graph_top + @graph_height * (1 - @zero) - 1
       else
-        result[0] = @graph_top + @graph_height*(1 - (val-@zero)) + 1
-        result[1] = @graph_top + @graph_height*(1 - @zero) - 1
+        result[0] = @graph_top + @graph_height * (1 - (val - @zero)) + 1
+        result[1] = @graph_top + @graph_height * (1 - @zero) - 1
       end
     else
       result[0] = 0.0

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -241,7 +241,7 @@ module Gruff
     def initialize_ivars
       # Internal for calculations
       @raw_columns = 800.0
-      @raw_rows = 800.0 * (@rows/@columns)
+      @raw_rows = 800.0 * (@rows / @columns)
       @column_count = 0
       @data = Array.new
       @marker_count = nil
@@ -564,7 +564,7 @@ module Gruff
         # Make space for half the width of the rightmost column label.
         # Might be greater than the number of columns if between-style bar markers are used.
         last_label = @labels.keys.sort.last.to_i
-        extra_room_for_long_label = (last_label >= (@column_count-1) && @center_labels_over_point) ?
+        extra_room_for_long_label = (last_label >= (@column_count - 1) && @center_labels_over_point) ?
             calculate_width(@marker_font_size, @labels[last_label]) / 2.0 :
             0
         @graph_right_margin = @right_margin + extra_room_for_long_label
@@ -898,7 +898,7 @@ module Gruff
       @d.pointsize = scale_fontsize(80)
       @d.gravity = CenterGravity
       @d = @d.annotate_scaled(@base_image,
-                              @raw_columns, @raw_rows/2.0,
+                              @raw_columns, @raw_rows / 2.0,
                               0, 10,
                               @no_data_message, @scale)
     end
@@ -1098,7 +1098,7 @@ module Gruff
                 else
                   value.to_s
                 end
-              elsif (@spread.to_f % (@marker_count.to_f==0 ? 1 : @marker_count.to_f) == 0) || !@y_axis_increment.nil?
+              elsif (@spread.to_f % (@marker_count.to_f == 0 ? 1 : @marker_count.to_f) == 0) || !@y_axis_increment.nil?
                 value.to_i.to_s
               elsif @spread > 10.0
                 sprintf('%0i', value)
@@ -1137,7 +1137,7 @@ module Gruff
 
     # Used for degree => radian conversions
     def deg2rad(angle)
-      angle * (Math::PI/180.0)
+      angle * (Math::PI / 180.0)
     end
 
   end # Gruff::Base

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -103,7 +103,7 @@ class Gruff::Bullet < Gruff::Base
       *[
         @base_image,
         1.0, 1.0,
-        @font_height/2, @font_height/2,
+        @font_height / 2, @font_height / 2,
         @title,
         @scale
       ]

--- a/lib/gruff/dot.rb
+++ b/lib/gruff/dot.rb
@@ -24,7 +24,7 @@ class Gruff::Dot < Gruff::Base
     @norm_data.each_with_index do |data_row, row_index|
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|
         x_pos = @graph_left + (data_point * @graph_width)
-        y_pos = @graph_top + (@items_width * point_index) + padding + (@items_width.to_f/2.0).round
+        y_pos = @graph_top + (@items_width * point_index) + padding + (@items_width.to_f / 2.0).round
 
         if row_index == 0
           @d = @d.stroke(@marker_color)
@@ -38,7 +38,7 @@ class Gruff::Dot < Gruff::Base
 
         @d = @d.fill data_row[DATA_COLOR_INDEX]
         @d = @d.stroke('transparent')
-        @d = @d.circle(x_pos, y_pos, x_pos + (@item_width.to_f/3.0).round, y_pos)
+        @d = @d.circle(x_pos, y_pos, x_pos + (@item_width.to_f / 3.0).round, y_pos)
 
         draw_label(y_pos, point_index)
       end

--- a/lib/gruff/mini/legend.rb
+++ b/lib/gruff/mini/legend.rb
@@ -41,7 +41,7 @@ module Gruff
 
       def calculate_legend_width
         width = @legend_labels.map { |label| calculate_width(@legend_font_size, label) }.max
-        scale_fontsize(width + 40*1.7)
+        scale_fontsize(width + 40 * 1.7)
       end
 
       ##
@@ -103,7 +103,7 @@ module Gruff
       def truncate_legend_label(label)
         truncated_label = label.to_s
         while calculate_width(scale_fontsize(@legend_font_size), truncated_label) > (@columns - @legend_left_margin - @right_margin) && (truncated_label.length > 1)
-          truncated_label = truncated_label[0..truncated_label.length-2]
+          truncated_label = truncated_label[0..truncated_label.length - 2]
         end
         truncated_label + (truncated_label.length < label.to_s.length ? "..." : '')
       end

--- a/lib/gruff/net.rb
+++ b/lib/gruff/net.rb
@@ -88,7 +88,7 @@ class Gruff::Net < Gruff::Base
     @d = @d.stroke(@marker_color)
     @d = @d.stroke_width 1
 
-    (0..@column_count-1).each do |index|
+    (0..@column_count - 1).each do |index|
       rad_pos = index * Math::PI * 2 / @column_count
 
       @d = @d.line(@center_x, @center_y, @center_x + Math::sin(rad_pos) * @radius, @center_y - Math::cos(rad_pos) * @radius)

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -177,7 +177,7 @@ class Gruff::Scatter < Gruff::Base
     super(name, y_data_points, color)
 
     #append the x data to the last entry that was just added in the @data member
-    last_elem = @data.length()-1
+    last_elem = @data.length() - 1
     @data[last_elem] << x_data_points
 
     if @maximum_x_value.nil? && @minimum_x_value.nil?

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -58,7 +58,7 @@ protected
         # Calculate center based on bar_width and current row
 
         if @use_data_label
-          label_center = @graph_top + (@bar_width * (row_index+point_index) + @bar_width / 2)
+          label_center = @graph_top + (@bar_width * (row_index + point_index) + @bar_width / 2)
           draw_label(label_center, row_index, @norm_data[row_index][DATA_LABEL_INDEX])
         else
           label_center = @graph_top + (@bars_width * point_index + @bars_width / 2)
@@ -66,7 +66,7 @@ protected
         end
         if @show_labels_for_bar_values
           val = (@label_formatting || '%.2f') % @norm_data[row_index][3][point_index]
-          draw_value_label(right_x+40, (@graph_top + (((row_index+point_index+1) * @bar_width) - (@bar_width / 2)))-12, val.commify, true)
+          draw_value_label(right_x + 40, (@graph_top + (((row_index + point_index + 1) * @bar_width) - (@bar_width / 2))) - 12, val.commify, true)
         end
       end
     end

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -35,7 +35,7 @@ protected
     padding = (@bar_width * (1 - @bar_spacing)) / 2
     if @show_labels_for_bar_values
       label_values = Array.new
-      0.upto(@column_count-1) { |i| label_values[i] = {:value => 0, :right_x => 0} }
+      0.upto(@column_count - 1) { |i| label_values[i] = {:value => 0, :right_x => 0} }
     end
     @norm_data.each_with_index do |data_row, row_index|
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|
@@ -77,7 +77,7 @@ protected
     if @show_labels_for_bar_values
       label_values.each_with_index do |data, i|
         val = (@label_formatting || "%.2f") % data[:value]
-        draw_value_label(data[:right_x]+40, (@graph_top + (((i+1) * @bar_width) - (@bar_width / 2)))-12, val.commify, true)
+        draw_value_label(data[:right_x] + 40, (@graph_top + (((i + 1) * @bar_width) - (@bar_width / 2))) - 12, val.commify, true)
       end
     end
 

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -41,7 +41,7 @@ class Gruff::Spider < Gruff::Base
 
     @unit_length = radius / @max_value
 
-    additive_angle = (2 * Math::PI)/ @data.size
+    additive_angle = (2 * Math::PI) / @data.size
 
     # Draw axes
     draw_axes(center_x, center_y, radius, additive_angle) unless hide_axes

--- a/lib/gruff/stacked_area.rb
+++ b/lib/gruff/stacked_area.rb
@@ -39,9 +39,9 @@ class Gruff::StackedArea < Gruff::Base
 
       if prev_data_points
         poly_points = data_points.dup
-        (prev_data_points.length/2 - 1).downto(0) do |i|
-          poly_points << prev_data_points[2*i]
-          poly_points << prev_data_points[2*i+1]
+        (prev_data_points.length / 2 - 1).downto(0) do |i|
+          poly_points << prev_data_points[2 * i]
+          poly_points << prev_data_points[2 * i + 1]
         end
         poly_points << data_points[0]
         poly_points << data_points[1]

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -397,8 +397,8 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new(600)
     g.hide_legend = true
     g.title = 'Full speed ahead'
-    g.labels = (0..10).inject({}) { |memo, i| memo.merge({i => (i*10).to_s}) }
-    g.data(:apples, (0..9).map { rand(20)/10.0 })
+    g.labels = (0..10).inject({}) { |memo, i| memo.merge({i => (i * 10).to_s}) }
+    g.data(:apples, (0..9).map { rand(20) / 10.0 })
     g.y_axis_increment = 1.0
     g.x_axis_label = 'Score (%)'
     g.y_axis_label = 'Students'

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -227,7 +227,7 @@ class TestGruffDot < GruffTestCase
     g = Gruff::Dot.new(600)
     g.hide_legend = true
     g.title = 'Full speed ahead'
-    g.labels = (0..10).inject({}) { |memo, i| memo.merge({ i => (i*10).to_s}) }
+    g.labels = (0..10).inject({}) { |memo, i| memo.merge({ i => (i * 10).to_s}) }
     g.data(:apples, [1.7, 0.8, 0.1, 1.9, 1.4, 0.6, 1.1, 0.7, 1.4, 0.2])
     g.y_axis_increment = 1.0
     g.x_axis_label = 'Score (%)'

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -63,7 +63,7 @@ class TestGruffScatter < Minitest::Test
     # Fake data (100 days, random times of day between 5 and 16)
     r = Random.new(269155)
     y_values = (0..100).map { 5 + r.rand(12) }
-    x_values = (0..100).map { |i| Date.today.strftime('%s').to_i + i*3600*24 }
+    x_values = (0..100).map { |i| Date.today.strftime('%s').to_i + i * 3600 * 24 }
     g.data('many points', x_values, y_values)
     g.write('test/output/scatter_custom_label_format.png')
   end


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/SpaceAroundOperators --auto-correct