### PR TITLE
Rubocop: Remove redundant splat expansion

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -280,12 +280,6 @@ Lint/ParenthesesAsGroupedExpression:
     - 'Rakefile'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Lint/RedundantSplatExpansion:
-  Exclude:
-    - 'lib/gruff/bullet.rb'
-
-# Offense count: 1
 Lint/RescueException:
   Exclude:
     - 'Rakefile'

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -100,13 +100,7 @@ class Gruff::Bullet < Gruff::Base
     @d.pointsize   = scale_fontsize(@title_font_size)
     @d.gravity     = NorthWestGravity
     @d             = @d.annotate_scaled(
-      *[
-        @base_image,
-        1.0, 1.0,
-        @font_height / 2, @font_height / 2,
-        @title,
-        @scale
-      ]
+      @base_image, 1.0, 1.0, @font_height / 2, @font_height / 2, @title, @scale
     )
   end
 


### PR DESCRIPTION
$ bundle exec rubocop --only Lint/RedundantSplatExpansion --auto-correct