### PR TITLE
Rubocop: Fix indentation in block

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,14 +32,6 @@ Layout/ArgumentAlignment:
 
 # Offense count: 2
 # Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleAlignWith.
-# SupportedStylesAlignWith: either, start_of_block, start_of_line
-Layout/BlockAlignment:
-  Exclude:
-    - 'lib/gruff/scatter.rb'
-
-# Offense count: 2
-# Cop supports --auto-correct.
 # Configuration parameters: Categories, ExpectedOrder.
 # ExpectedOrder: module_inclusion, constants, public_class_methods, initializer, public_methods, protected_methods, private_methods
 Layout/ClassStructure:

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -206,12 +206,12 @@ protected
       @data.each do |data_row|
         norm_data_points = [data_row[DATA_LABEL_INDEX]]
         norm_data_points << data_row[DATA_VALUES_INDEX].map do |r|
-                              (r.to_f - @minimum_value.to_f) / @spread
-                            end
+          (r.to_f - @minimum_value.to_f) / @spread
+        end
         norm_data_points << data_row[DATA_COLOR_INDEX]
         norm_data_points << data_row[DATA_VALUES_X_INDEX].map do |r|
-                              (r.to_f - @minimum_x_value.to_f) / @x_spread
-                            end
+          (r.to_f - @minimum_x_value.to_f) / @x_spread
+        end
         @norm_data << norm_data_points
       end
     end


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/BlockAlignment --auto-correct