### PR TITLE
Rubocop: Fix Hash syntax style

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,3 +8,6 @@ AllCops:
 
 Layout/AccessModifierIndentation:
   EnforcedStyle: outdent
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19_no_mixed_keys

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -651,13 +651,6 @@ Style/GuardClause:
     - 'lib/gruff/scatter.rb'
     - 'lib/gruff/side_bar.rb'
 
-# Offense count: 141
-# Cop supports --auto-correct.
-# Configuration parameters: UseHashRocketsWithSymbolValues, PreferHashRocketsForNonAlnumEndingSymbols.
-# SupportedStyles: ruby19, hash_rockets, no_mixed_keys, ruby19_no_mixed_keys
-Style/HashSyntax:
-  EnforcedStyle: hash_rockets
-
 # Offense count: 8
 Style/IdenticalConditionalBranches:
   Exclude:

--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,15 @@ require 'rake/clean'
 CLEAN.concat %w(pkg test/output/*)
 
 desc 'Run tests'
-task :default => :test
+task default: :test
 
-task :gem => :build
+task gem: :build
 
 Rake::TestTask.new
 
 namespace :test do
   desc 'Run mini tests'
-  task :mini => :clean do
+  task mini: :clean do
     Dir['test/test_mini*'].each do |file|
       system "ruby #{file}"
     end

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -348,13 +348,13 @@ module Gruff
       reset_themes
 
       defaults = {
-        :colors => %w(black white),
-        :additional_line_colors => [],
-        :marker_color => 'white',
-        :marker_shadow_color => nil,
-        :font_color => 'black',
-        :background_colors => nil,
-        :background_image => nil
+        colors: %w(black white),
+        additional_line_colors: [],
+        marker_color: 'white',
+        marker_shadow_color: nil,
+        font_color: 'black',
+        background_colors: nil,
+        background_image: nil
       }
       @theme_options = defaults.merge options
 
@@ -1167,7 +1167,7 @@ module Magick
       #              Remove this method as soon as RMagick4J Issue #16 is fixed.
       #              https://github.com/Serabe/RMagick4J/issues/16
       def fill=(fill)
-        fill = {:white => '#FFFFFF'}[fill.to_sym] || fill
+        fill = {white: '#FFFFFF'}[fill.to_sym] || fill
         @draw.fill = Magick4J.ColorDatabase.query_default(fill)
         self
       end

--- a/lib/gruff/pie.rb
+++ b/lib/gruff/pie.rb
@@ -50,10 +50,10 @@ class Gruff::Pie < Gruff::Base
 
   def options
     {
-      :zero_degree            => zero_degree,
-      :hide_labels_less_than  => hide_labels_less_than,
-      :text_offset_percentage => text_offset_percentage,
-      :show_values_as_labels  => show_values_as_labels
+      zero_degree: zero_degree,
+      hide_labels_less_than: hide_labels_less_than,
+      text_offset_percentage: text_offset_percentage,
+      show_values_as_labels: show_values_as_labels
     }
   end
 

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -35,7 +35,7 @@ protected
     padding = (@bar_width * (1 - @bar_spacing)) / 2
     if @show_labels_for_bar_values
       label_values = Array.new
-      0.upto(@column_count - 1) { |i| label_values[i] = {:value => 0, :right_x => 0} }
+      0.upto(@column_count - 1) { |i| label_values[i] = {value: 0, right_x: 0} }
     end
     @norm_data.each_with_index do |data_row, row_index|
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|

--- a/lib/gruff/themes.rb
+++ b/lib/gruff/themes.rb
@@ -3,7 +3,7 @@ module Gruff
 
     # A color scheme similar to the popular presentation software.
     KEYNOTE = {
-      :colors => [
+      colors: [
         '#FDD84E',  # yellow
         '#6886B4',  # blue
         '#72AE6E',  # green
@@ -12,14 +12,14 @@ module Gruff
         '#EFAA43',  # orange
         'white'
       ],
-      :marker_color => 'white',
-      :font_color => 'white',
-      :background_colors => %w(black #4a465a)
+      marker_color: 'white',
+      font_color: 'white',
+      background_colors: %w(black #4a465a)
     }
 
     # A color scheme plucked from the colors on the popular usability blog.
     THIRTYSEVEN_SIGNALS = {
-      :colors => [
+      colors: [
         '#FFF804',  # yellow
         '#336699',  # blue
         '#339933',  # green
@@ -28,15 +28,15 @@ module Gruff
         '#cf5910',  # orange
         'black'
       ],
-      :marker_color => 'black',
-      :font_color => 'black',
-      :background_colors => %w(#d1edf5 white)
+      marker_color: 'black',
+      font_color: 'black',
+      background_colors: %w(#d1edf5 white)
     }
 
     # A color scheme from the colors used on the 2005 Rails keynote
     # presentation at RubyConf.
     RAILS_KEYNOTE = {
-      :colors => [
+      colors: [
         '#00ff00',  # green
         '#333333',  # grey
         '#ff5d00',  # orange
@@ -45,14 +45,14 @@ module Gruff
         '#999999',  # light grey
         'black'
       ],
-      :marker_color => 'white',
-      :font_color => 'white',
-      :background_colors => %w(#0083a3 #0083a3)
+      marker_color: 'white',
+      font_color: 'white',
+      background_colors: %w(#0083a3 #0083a3)
     }
 
     # A color scheme similar to that used on the popular podcast site.
     ODEO = {
-      :colors => [
+      colors: [
         '#202020',  # grey
         'white',
         '#3a5b87',  # dark blue
@@ -61,14 +61,14 @@ module Gruff
         '#999999',  # light grey
         'black'
       ],
-      :marker_color => 'white',
-      :font_color => 'white',
-      :background_colors => %w(#ff47a4 #ff1f81)
+      marker_color: 'white',
+      font_color: 'white',
+      background_colors: %w(#ff47a4 #ff1f81)
     }
 
     # A pastel theme
     PASTEL = {
-      :colors => [
+      colors: [
         '#a9dada', # blue
         '#aedaa9', # green
         '#daaea9', # peach
@@ -77,14 +77,14 @@ module Gruff
         '#daaeda', # purple
         '#dadada' # grey
       ],
-      :marker_color => '#aea9a9', # Grey
-      :font_color => 'black',
-      :background_colors => 'white'
+      marker_color: '#aea9a9', # Grey
+      font_color: 'black',
+      background_colors: 'white'
     }
 
     # A greyscale theme
     GREYSCALE = {
-      :colors => [
+      colors: [
         '#282828',
         '#383838',
         '#686868',
@@ -92,9 +92,9 @@ module Gruff
         '#c8c8c8',
         '#e8e8e8',
       ],
-      :marker_color => '#aea9a9', # Grey
-      :font_color => 'black',
-      :background_colors => 'white'
+      marker_color: '#aea9a9', # Grey
+      font_color: 'black',
+      background_colors: 'white'
     }
 
   end

--- a/test/test_accumulator_bar.rb
+++ b/test/test_accumulator_bar.rb
@@ -21,10 +21,10 @@ class TestGruffAccumulatorBar < GruffTestCase
     g.marker_font_size = 18
 
     g.theme = {
-      :colors => ['#aedaa9', '#12a702'],
-      :marker_color => '#dddddd',
-      :font_color => 'black',
-      :background_colors => 'white'
+      colors: ['#aedaa9', '#12a702'],
+      marker_color: '#dddddd',
+      font_color: 'black',
+      background_colors: 'white'
       # :background_image => File.expand_path(File.dirname(__FILE__) + "/../assets/backgrounds/43things.png")
     }
 

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -271,10 +271,10 @@ class TestGruffBar < GruffTestCase
     g.legend_font_size = 32
     g.marker_font_size = 32
     g.theme = {
-      :colors => %w(#efd250 #666699 #e5573f #9595e2),
-      :marker_color => 'white',
-      :font_color => 'blue',
-      :background_image => 'assets/pc306715.jpg'
+      colors: %w(#efd250 #666699 #e5573f #9595e2),
+      marker_color: 'white',
+      font_color: 'blue',
+      background_image: 'assets/pc306715.jpg'
     }
     g.labels = {
       0 => '5/6',
@@ -294,8 +294,8 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient top to bottom'
     g.theme = {
-      :background_colors => %w(#ff0000 #00ff00),
-      :background_direction => :top_bottom,
+      background_colors: %w(#ff0000 #00ff00),
+      background_direction: :top_bottom,
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -309,8 +309,8 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient top to bottom'
     g.theme = {
-      :background_colors => %w(#ff0000 #00ff00),
-      :background_direction => :bottom_top,
+      background_colors: %w(#ff0000 #00ff00),
+      background_direction: :bottom_top,
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -324,8 +324,8 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient left to right'
     g.theme = {
-      :background_colors => %w(#ff0000 #00ff00),
-      :background_direction => :left_right,
+      background_colors: %w(#ff0000 #00ff00),
+      background_direction: :left_right,
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -339,8 +339,8 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient right to left'
     g.theme = {
-      :background_colors => %w(#ff0000 #00ff00),
-      :background_direction => :right_left,
+      background_colors: %w(#ff0000 #00ff00),
+      background_direction: :right_left,
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -354,8 +354,8 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient top left to bottom right'
     g.theme = {
-      :background_colors => %w(#ff0000 #00ff00),
-      :background_direction => :topleft_bottomright,
+      background_colors: %w(#ff0000 #00ff00),
+      background_direction: :topleft_bottomright,
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -370,8 +370,8 @@ class TestGruffBar < GruffTestCase
     g.title = 'Background gradient top right to bottom left'
     g.title_font_size = 30
     g.theme = {
-      :background_colors => %w(#ff0000 #00ff00),
-      :background_direction => :topright_bottomleft,
+      background_colors: %w(#ff0000 #00ff00),
+      background_direction: :topright_bottomleft,
     }
     g.labels = @labels
     @datasets.each do |name, values|

--- a/test/test_bezier.rb
+++ b/test/test_bezier.rb
@@ -4,9 +4,9 @@ class TestBezier < GruffTestCase
 
   def setup
     @data_args = [75, 100, {
-      :target => 80,
-      :low => 50,
-      :high => 90
+      target: 80,
+      low: 50,
+      high: 90
     }]
   end
 

--- a/test/test_bullet.rb
+++ b/test/test_bullet.rb
@@ -4,9 +4,9 @@ class TestGruffBullet < GruffTestCase
 
   def setup
     @data_args = [75, 100, {
-      :target => 80,
-      :low => 50,
-      :high => 90
+      target: 80,
+      low: 50,
+      high: 90
     }]
   end
 

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -204,10 +204,10 @@ class TestGruffDot < GruffTestCase
     g.legend_font_size = 32
     g.marker_font_size = 32
     g.theme = {
-      :colors => %w(#efd250 #666699 #e5573f #9595e2),
-      :marker_color => 'white',
-      :font_color => 'blue',
-      :background_image => 'assets/pc306715.jpg'
+      colors: %w(#efd250 #666699 #e5573f #9595e2),
+      marker_color: 'white',
+      font_color: 'blue',
+      background_image: 'assets/pc306715.jpg'
     }
     g.labels = {
       0 => '5/6',

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -7,10 +7,10 @@ class TestGruffLine < GruffTestCase
     g = Gruff::Line.new(400)
     g.title = 'Transparent Background'
     g.theme = {
-      :colors => %w(black grey),
-      :marker_color => 'grey',
-      :font_color => 'black',
-      :background_colors => 'transparent'
+      colors: %w(black grey),
+      marker_color: 'grey',
+      font_color: 'black',
+      background_colors: 'transparent'
     }
 
     g.labels = {
@@ -403,57 +403,57 @@ class TestGruffLine < GruffTestCase
     g.title = 'Line Test, Many Numbers'
 
     data = [
-      {:date => '01',
-       :wpm => 0,
-       :errors => 0,
-       :accuracy => 0},
-      {:date => '02',
-       :wpm => 10,
-       :errors => 2,
-       :accuracy => 80},
-      {:date => '03',
-       :wpm => 15,
-       :errors => 0,
-       :accuracy => 100},
-      {:date => '04',
-       :wpm => 16,
-       :errors => 2,
-       :accuracy => 87},
-      {:date => '05'},
-      {:date => '06',
-       :wpm => 18,
-       :errors => 1,
-       :accuracy => 94},
-      {:date => '07'},
-      {:date => '08'},
-      {:date => '09',
-       :wpm => 21,
-       :errors => 1,
-       :accuracy => 95},
-      {:date => '10'},
-      {:date => '11'},
-      {:date => '12'},
-      {:date => '13'},
-      {:date => '14'},
-      {:date => '15'},
-      {:date => '16'},
-      {:date => '17'},
-      {:date => '18'},
-      {:date => '19',
-       :wpm => 28,
-       :errors => 5,
-       :accuracy => 82},
-      {:date => '20'},
-      {:date => '21'},
-      {:date => '22'},
-      {:date => '23'},
-      {:date => '24'},
-      {:date => '25'},
-      {:date => '26'},
-      {:date => '27',
-       :wpm => 37,
-       :errors => 3,
-       :accuracy => 92},
+      {date: '01',
+       wpm: 0,
+       errors: 0,
+       accuracy: 0},
+      {date: '02',
+       wpm: 10,
+       errors: 2,
+       accuracy: 80},
+      {date: '03',
+       wpm: 15,
+       errors: 0,
+       accuracy: 100},
+      {date: '04',
+       wpm: 16,
+       errors: 2,
+       accuracy: 87},
+      {date: '05'},
+      {date: '06',
+       wpm: 18,
+       errors: 1,
+       accuracy: 94},
+      {date: '07'},
+      {date: '08'},
+      {date: '09',
+       wpm: 21,
+       errors: 1,
+       accuracy: 95},
+      {date: '10'},
+      {date: '11'},
+      {date: '12'},
+      {date: '13'},
+      {date: '14'},
+      {date: '15'},
+      {date: '16'},
+      {date: '17'},
+      {date: '18'},
+      {date: '19',
+       wpm: 28,
+       errors: 5,
+       accuracy: 82},
+      {date: '20'},
+      {date: '21'},
+      {date: '22'},
+      {date: '23'},
+      {date: '24'},
+      {date: '25'},
+      {date: '26'},
+      {date: '27',
+       wpm: 37,
+       errors: 3,
+       accuracy: 92},
     ]
 
     [:wpm, :errors, :accuracy].each do |field|
@@ -504,9 +504,9 @@ class TestGruffLine < GruffTestCase
   def test_jruby_error
     g = Gruff::Line.new
     g.theme = {
-      :colors => %w(#7F0099 #2F85ED #2FED09 #EC962F),
-      :marker_color => '#aaa',
-      :background_colors => %w(#E8E8E8 #B9FD6C)
+      colors: %w(#7F0099 #2F85ED #2FED09 #EC962F),
+      marker_color: '#aaa',
+      background_colors: %w(#E8E8E8 #B9FD6C)
     }
     g.hide_title = true
 
@@ -558,11 +558,11 @@ class TestGruffLine < GruffTestCase
 
     g.reference_line_default_width = 1
 
-    g.reference_lines[:baseline]  = { :value => 5 }
-    g.reference_lines[:lots]      = { :value => 9 }
-    g.reference_lines[:little]    = { :value => 3 }
-    g.reference_lines[:horiz_one] = { :index => 1, :color => 'green' }
-    g.reference_lines[:horiz_two] = { :index => 3, :color => 'green' }
+    g.reference_lines[:baseline]  = { value: 5 }
+    g.reference_lines[:lots]      = { value: 9 }
+    g.reference_lines[:little]    = { value: 3 }
+    g.reference_lines[:horiz_one] = { index: 1, color: 'green' }
+    g.reference_lines[:horiz_two] = { index: 3, color: 'green' }
 
     g.write('line_reference_lines.png')
   end

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -149,7 +149,7 @@ class TestGruffPie < GruffTestCase
       graph.title = "Subclassed Pie with Custom Lables"
 
       @datasets.map { |set| set << set.join(': ') }.each do |data|
-        graph.data(data[0], data[1], :label => data[2])
+        graph.data(data[0], data[1], label: data[2])
       end
 
       graph.write 'test/output/pie_subclass_custom_labels.png'

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -38,10 +38,10 @@ class TestGruffScatter < Minitest::Test
     g.hide_title = true
     g.marker_font_size = 10
     g.theme = {
-      :colors => ['#12a702', '#aedaa9'],
-      :marker_color => '#dddddd',
-      :font_color => 'black',
-      :background_colors => 'white'
+      colors: ['#12a702', '#aedaa9'],
+      marker_color: '#dddddd',
+      font_color: 'black',
+      background_colors: 'white'
     }
 
     # Points style


### PR DESCRIPTION
$ bundle exec rubocop --only Style/HashSyntax --auto-correct