### PR TITLE
Rubocop: Remove unnecessary parentheses in condition

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -830,16 +830,6 @@ Style/OptionHash:
     - 'lib/gruff/bullet.rb'
     - 'test/test_pie.rb'
 
-# Offense count: 8
-# Cop supports --auto-correct.
-# Configuration parameters: AllowSafeAssignment, AllowInMultilineConditions.
-Style/ParenthesesAroundCondition:
-  Exclude:
-    - 'lib/gruff/bar.rb'
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/line.rb'
-    - 'lib/gruff/stacked_bar.rb'
-
 # Offense count: 38
 # Cop supports --auto-correct.
 # Configuration parameters: PreferredDelimiters.

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -30,7 +30,7 @@ class Gruff::Bar < Gruff::Base
   #
   # Default value is 0.9.
   def spacing_factor=(space_percent)
-    raise ArgumentError, 'spacing_factor must be between 0.00 and 1.00' unless (space_percent >= 0 and space_percent <= 1)
+    raise ArgumentError, 'spacing_factor must be between 0.00 and 1.00' unless space_percent >= 0 and space_percent <= 1
     @spacing_factor = (1 - space_percent)
   end
 

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -808,7 +808,7 @@ module Gruff
 
     # Draws a title on the graph.
     def draw_title
-      return if (@hide_title || @title.nil?)
+      return if @hide_title || @title.nil?
 
       @d.fill = @font_color
       @d.font = @title_font || @font if @title_font || @font

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -37,7 +37,7 @@ class Gruff::Line < Gruff::Base
 
   # Get the value if somebody has defined it.
   def baseline_value
-    if (@reference_lines.key?(:baseline))
+    if @reference_lines.key?(:baseline)
       @reference_lines[:baseline][:value]
     else
       nil
@@ -51,7 +51,7 @@ class Gruff::Line < Gruff::Base
   end
 
   def baseline_color
-    if (@reference_lines.key?(:baseline))
+    if @reference_lines.key?(:baseline)
       @reference_lines[:baseline][:color]
     else
       nil
@@ -193,7 +193,7 @@ class Gruff::Line < Gruff::Base
       draw_vertical_reference_line(curr_reference_line) if curr_reference_line.key?(:index)
     end
 
-    if (@show_vertical_markers)
+    if @show_vertical_markers
       (0..@column_count).each do |column|
         x = @graph_left + @graph_width - column.to_f * @x_increment
 
@@ -274,7 +274,7 @@ class Gruff::Line < Gruff::Base
     possible_minimums = [@minimum_value.to_f]
 
     @reference_lines.each_value do |curr_reference_line|
-      if (curr_reference_line.key?(:value))
+      if curr_reference_line.key?(:value)
         possible_maximums << curr_reference_line[:value].to_f
         possible_minimums << curr_reference_line[:value].to_f
       end
@@ -293,7 +293,7 @@ class Gruff::Line < Gruff::Base
       # We only care about horizontal markers ... for normalization.
       # Vertical markers won't have a :value, they will have an :index
 
-      curr_reference_line[:norm_value] = ((curr_reference_line[:value].to_f - @minimum_value) / @spread.to_f) if (curr_reference_line.key?(:value))
+      curr_reference_line[:norm_value] = ((curr_reference_line[:value].to_f - @minimum_value) / @spread.to_f) if curr_reference_line.key?(:value)
     end
 
     #normalize the x data if it is specified

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -36,7 +36,7 @@ class Gruff::StackedBar < Gruff::Base
         label_center = @graph_left + (@bar_width * point_index) + (@bar_width * @bar_spacing / 2.0)
         draw_label(label_center, point_index)
 
-        next if (data_point == 0)
+        next if data_point == 0
         # Use incremented x and scaled y
         left_x = @graph_left + (@bar_width * point_index) + padding
         left_y = @graph_top + (@graph_height -


### PR DESCRIPTION
$ bundle exec rubocop --only Style/ParenthesesAroundCondition --auto-correct