### PR TITLE
Rubocop: Add space around Hash literal braces

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -223,22 +223,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/gruff/line.rb'
     - 'lib/gruff/net.rb'
 
-# Offense count: 79
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, EnforcedStyleForEmptyBraces.
-# SupportedStyles: space, no_space, compact
-# SupportedStylesForEmptyBraces: space, no_space
-Layout/SpaceInsideHashLiteralBraces:
-  Exclude:
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/side_stacked_bar.rb'
-    - 'test/gruff_test_case.rb'
-    - 'test/test_accumulator_bar.rb'
-    - 'test/test_bar.rb'
-    - 'test/test_dot.rb'
-    - 'test/test_line.rb'
-    - 'test/test_side_bar.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Layout/SpaceInsideRangeLiteral:
@@ -363,7 +347,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 131
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/MethodLength:
-  Max: 64
+  Max: 80
 
 # Offense count: 1
 # Configuration parameters: CountKeywordArgs.

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1167,7 +1167,7 @@ module Magick
       #              Remove this method as soon as RMagick4J Issue #16 is fixed.
       #              https://github.com/Serabe/RMagick4J/issues/16
       def fill=(fill)
-        fill = {white: '#FFFFFF'}[fill.to_sym] || fill
+        fill = { white: '#FFFFFF' }[fill.to_sym] || fill
         @draw.fill = Magick4J.ColorDatabase.query_default(fill)
         self
       end

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -35,7 +35,7 @@ protected
     padding = (@bar_width * (1 - @bar_spacing)) / 2
     if @show_labels_for_bar_values
       label_values = Array.new
-      0.upto(@column_count - 1) { |i| label_values[i] = {value: 0, right_x: 0} }
+      0.upto(@column_count - 1) { |i| label_values[i] = { value: 0, right_x: 0 } }
     end
     @norm_data.each_with_index do |data_row, row_index|
       data_row[DATA_VALUES_INDEX].each_with_index do |data_point, point_index|

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -72,7 +72,7 @@ class GruffTestCase < Minitest::Test
       ['Entertainment', 15]
     ]
 
-    @labels = {0 => 'This Month'}
+    @labels = { 0 => 'This Month' }
   end
 
   def test_dummy

--- a/test/test_accumulator_bar.rb
+++ b/test/test_accumulator_bar.rb
@@ -31,7 +31,7 @@ class TestGruffAccumulatorBar < GruffTestCase
     # Attempt at negative numbers
     # g.data 'Savings', (1..20).to_a.map { rand(10) * (rand(2) > 0 ? 1 : -1) }
     g.data 'Savings', (1..12).to_a.map { rand(100) }
-    g.labels = (0..11).to_a.inject({}) { |memo, index| {index => '12-26'}.merge(memo) }
+    g.labels = (0..11).to_a.inject({}) { |memo, index| { index => '12-26' }.merge(memo) }
 
     g.maximum_value = 1000
     g.minimum_value = 0

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -389,7 +389,7 @@ class TestGruffBar < GruffTestCase
     g.data('Oranges', [4, 8, 7, 9, 8, 9])
     g.data('Watermelon', [2, 3, 1, 5, 6, 8])
     g.data('Peaches', [9, 9, 10, 8, 7, 9])
-    g.labels = {0 => '2003', 2 => '2004', 4 => '2005'}
+    g.labels = { 0 => '2003', 2 => '2004', 4 => '2005' }
     g.write('test/output/bar_long_legend_text.png')
   end
 
@@ -397,7 +397,7 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new(600)
     g.hide_legend = true
     g.title = 'Full speed ahead'
-    g.labels = (0..10).inject({}) { |memo, i| memo.merge({i => (i * 10).to_s}) }
+    g.labels = (0..10).inject({}) { |memo, i| memo.merge({ i => (i * 10).to_s }) }
     g.data(:apples, (0..9).map { rand(20) / 10.0 })
     g.y_axis_increment = 1.0
     g.x_axis_label = 'Score (%)'

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -227,7 +227,7 @@ class TestGruffDot < GruffTestCase
     g = Gruff::Dot.new(600)
     g.hide_legend = true
     g.title = 'Full speed ahead'
-    g.labels = (0..10).inject({}) { |memo, i| memo.merge({ i => (i * 10).to_s}) }
+    g.labels = (0..10).inject({}) { |memo, i| memo.merge({ i => (i * 10).to_s }) }
     g.data(:apples, [1.7, 0.8, 0.1, 1.9, 1.4, 0.6, 1.1, 0.7, 1.4, 0.2])
     g.y_axis_increment = 1.0
     g.x_axis_label = 'Score (%)'

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -403,57 +403,73 @@ class TestGruffLine < GruffTestCase
     g.title = 'Line Test, Many Numbers'
 
     data = [
-      {date: '01',
-       wpm: 0,
-       errors: 0,
-       accuracy: 0},
-      {date: '02',
-       wpm: 10,
-       errors: 2,
-       accuracy: 80},
-      {date: '03',
-       wpm: 15,
-       errors: 0,
-       accuracy: 100},
-      {date: '04',
-       wpm: 16,
-       errors: 2,
-       accuracy: 87},
-      {date: '05'},
-      {date: '06',
-       wpm: 18,
-       errors: 1,
-       accuracy: 94},
-      {date: '07'},
-      {date: '08'},
-      {date: '09',
-       wpm: 21,
-       errors: 1,
-       accuracy: 95},
-      {date: '10'},
-      {date: '11'},
-      {date: '12'},
-      {date: '13'},
-      {date: '14'},
-      {date: '15'},
-      {date: '16'},
-      {date: '17'},
-      {date: '18'},
-      {date: '19',
-       wpm: 28,
-       errors: 5,
-       accuracy: 82},
-      {date: '20'},
-      {date: '21'},
-      {date: '22'},
-      {date: '23'},
-      {date: '24'},
-      {date: '25'},
-      {date: '26'},
-      {date: '27',
-       wpm: 37,
-       errors: 3,
-       accuracy: 92},
+      {
+        date: '01',
+        wpm: 0,
+        errors: 0,
+        accuracy: 0
+      },
+      {
+        date: '02',
+        wpm: 10,
+        errors: 2,
+        accuracy: 80
+      },
+      {
+        date: '03',
+        wpm: 15,
+        errors: 0,
+        accuracy: 100
+      },
+      {
+        date: '04',
+        wpm: 16,
+        errors: 2,
+        accuracy: 87
+      },
+      { date: '05' },
+      {
+        date: '06',
+        wpm: 18,
+        errors: 1,
+        accuracy: 94
+      },
+      { date: '07' },
+      { date: '08' },
+      {
+        date: '09',
+        wpm: 21,
+        errors: 1,
+        accuracy: 95
+      },
+      { date: '10' },
+      { date: '11' },
+      { date: '12' },
+      { date: '13' },
+      { date: '14' },
+      { date: '15' },
+      { date: '16' },
+      { date: '17' },
+      { date: '18' },
+      {
+        date: '19',
+        wpm: 28,
+        errors: 5,
+        accuracy: 82
+      },
+      { date: '20' },
+      { date: '21' },
+      { date: '22' },
+      { date: '23' },
+      { date: '24' },
+      { date: '25' },
+      { date: '26' },
+      {
+        date: '27',
+        wpm: 37,
+        errors: 3,
+        accuracy: 92
+      },
     ]
 
     [:wpm, :errors, :accuracy].each do |field|
@@ -485,7 +501,7 @@ class TestGruffLine < GruffTestCase
     g.dataxy('Apples', [1, 3, 4, 5, 6, 10], [1, 2, 3, 4, 4, 3])
     g.dataxy('Bapples', [1, 3, 4, 5, 7, 9], [1, 1, 2, 2, 3, 3])
     g.data('Capples', [1, 1, 2, 2, 3, 3])
-    g.labels = {0 => '2003', 2 => '2004', 4 => '2005', 6 => '2006', 8 => '2007', 10 => '2008'}
+    g.labels = { 0 => '2003', 2 => '2004', 4 => '2005', 6 => '2006', 8 => '2007', 10 => '2008' }
     g.write('test/output/line_xy.png')
   end
 
@@ -497,7 +513,7 @@ class TestGruffLine < GruffTestCase
     g.data('Capples', [1, 1, 2, 2, 3, 3])
     g.dataxy('Dapples', [[1, 1], [2, 2], [5, 6], [13, 13], [15, nil], [2, 17], [3, nil], [3, 17], [13, nil], [3, 18], [5, nil], [2, 18]])
     g.dataxy('Eapples', [[1, 1], [2, 3], [5, 8], [13, 21], [13, 8], [5, 3], [2, 1], [1, 1]])
-    g.labels = {0 => '2003', 2 => '2004', 4 => '2005', 6 => '2006', 8 => '2007', 10 => '2008', 12 => '2009'}
+    g.labels = { 0 => '2003', 2 => '2004', 4 => '2005', 6 => '2006', 8 => '2007', 10 => '2008', 12 => '2009' }
     g.write('test/output/line_xy_pairs.png')
   end
 
@@ -554,7 +570,7 @@ class TestGruffLine < GruffTestCase
     g.data('Watermelon', [2, 3, 4, 5, 6, 8])
     g.data('Peaches', [9, 9, 10, 8, 7, 9])
 
-    g.labels = {0 => '2003', 2 => '2004', 4 => '2005'}
+    g.labels = { 0 => '2003', 2 => '2004', 4 => '2005' }
 
     g.reference_line_default_width = 1
 
@@ -576,7 +592,7 @@ class TestGruffLine < GruffTestCase
     g.data('Watermelon', [2, 3, 4, 5, 6, 8])
     g.data('Peaches', [9, 9, 10, 8, 7, 9])
 
-    g.labels = {0 => '2003', 2 => '2004', 4 => '2005'}
+    g.labels = { 0 => '2003', 2 => '2004', 4 => '2005' }
     g.baseline_value = 5
 
     g.write('line_baseline.png')

--- a/test/test_side_bar.rb
+++ b/test/test_side_bar.rb
@@ -34,7 +34,7 @@ class TestGruffSideBar < GruffTestCase
     g.data("Oranges", [32])
     g.data("Watermelon", [8])
     g.data("Peaches", [12])
-    g.labels = {0 => '2003', 2 => '2004', 4 => '2005'}
+    g.labels = { 0 => '2003', 2 => '2004', 4 => '2005' }
     g.write("test/output/side_bar_data_range.png")
   end
 
@@ -46,7 +46,7 @@ class TestGruffSideBar < GruffTestCase
     g.data("Oranges", [32])
     g.data("Watermelon", [8])
     g.data("Peaches", [12])
-    g.labels = {0 => '2003', 2 => '2004', 4 => '2005'}
+    g.labels = { 0 => '2003', 2 => '2004', 4 => '2005' }
     g.show_labels_for_bar_values = true
     g.write("test/output/side_bar_labels.png")
   end


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/SpaceInsideHashLiteralBraces --auto-correct