### PR TITLE
Rubocop: Add blank line after guard clause

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -55,21 +55,6 @@ Layout/CommentIndentation:
     - 'test/test_sidestacked_bar.rb'
     - 'test/test_spider.rb'
 
-# Offense count: 12
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterGuardClause:
-  Exclude:
-    - 'Rakefile'
-    - 'lib/gruff/bar.rb'
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/bullet.rb'
-    - 'lib/gruff/line.rb'
-    - 'lib/gruff/photo_bar.rb'
-    - 'lib/gruff/scene.rb'
-    - 'lib/gruff/side_bar.rb'
-    - 'lib/gruff/stacked_bar.rb'
-    - 'test/image_compare.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Layout/EmptyLineAfterMagicComment:

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,7 @@ end
 desc 'Generate release docs for a given milestone'
 task :release_docs do
   raise "\n    This task requires Ruby 1.9 or newer to parse JSON as YAML.\n\n" if RUBY_VERSION == '1.8.7'
+
   categories, grouped_issues, milestone, milestone_description, milestone_name = get_github_issues
 
   puts '=' * 80

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -31,6 +31,7 @@ class Gruff::Bar < Gruff::Base
   # Default value is 0.9.
   def spacing_factor=(space_percent)
     raise ArgumentError, 'spacing_factor must be between 0.00 and 1.00' unless space_percent >= 0 and space_percent <= 1
+
     @spacing_factor = (1 - space_percent)
   end
 

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -994,6 +994,7 @@ module Gruff
 
     def significant(i) # :nodoc:
       return 1.0 if i == 0 # Keep from going into infinite loop
+
       inc = BigDecimal(i.to_s)
       factor = BigDecimal('1.0')
       while inc < 10
@@ -1130,6 +1131,7 @@ module Gruff
     # scaling will handle.
     def calculate_width(font_size, text)
       return 0 if text.nil?
+
       @d.pointsize = font_size
       @d.font = @font if @font
       @d.get_type_metrics(@base_image, text.to_s).width

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -68,6 +68,7 @@ class Gruff::Bullet < Gruff::Base
 
     [:high, :low].each_with_index do |indicator, index|
       next unless @options.has_key?(indicator)
+
       @d = @d.fill @colors[index + 1]
       indicator_width_x = @graph_left + @graph_width * (@options[indicator] / @maximum_value)
       @d = @d.rectangle(@graph_left, 0, indicator_width_x, @graph_height)

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -74,6 +74,7 @@ class Gruff::Line < Gruff::Base
   # The preferred way is to call hide_dots or hide_lines instead.
   def initialize(*args)
     raise ArgumentError, 'Wrong number of arguments' if args.length > 2
+
     if args.empty? || ((not Numeric === args.first) && (not String === args.first))
       super()
     else
@@ -326,6 +327,7 @@ class Gruff::Line < Gruff::Base
           # more than one point, bail
           return false
         end
+
         # there is at least one data point
         one_point = true
       end

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -88,6 +88,7 @@ protected
 
     Dir.open(theme_dir).each do |file|
       next unless /\.png$/.match(file)
+
       color_list << Image.read("#{theme_dir}/#{file}").first
     end
     @colors = color_list

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -162,6 +162,7 @@ class Gruff::Layer
     unless @selected_filename.nil? || @selected_filename.empty?
       return File.join(@base_dir, @name, @selected_filename)
     end
+
     ''
   end
 

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -13,6 +13,7 @@ class Gruff::SideBar < Gruff::Base
     super
 
     return unless @has_data
+
     draw_bars
   end
 

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -37,6 +37,7 @@ class Gruff::StackedBar < Gruff::Base
         draw_label(label_center, point_index)
 
         next if data_point == 0
+
         # Use incremented x and scaled y
         left_x = @graph_left + (@bar_width * point_index) + padding
         left_y = @graph_top + (@graph_height -

--- a/test/image_compare.rb
+++ b/test/image_compare.rb
@@ -11,6 +11,7 @@ class ImageCompare
     new_file_name = "#{name}_1.png~"
 
     return nil unless File.exist? old_file_name
+
     images = [
       ChunkyPNG::Image.from_file(old_file_name),
       ChunkyPNG::Image.from_file(file_name),


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/EmptyLineAfterGuardClause --auto-correct