### PR TITLE
Rubocop: Fix alignment of multiline array

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -129,14 +129,6 @@ Layout/LeadingCommentSpace:
     - 'test/test_scatter.rb'
     - 'test/test_sidestacked_bar.rb'
 
-# Offense count: 22
-# Cop supports --auto-correct.
-Layout/MultilineArrayLineBreaks:
-  Exclude:
-    - 'test/test_bezier.rb'
-    - 'test/test_bullet.rb'
-    - 'test/test_spider.rb'
-
 # Offense count: 17
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/test/test_bezier.rb
+++ b/test/test_bezier.rb
@@ -3,11 +3,15 @@ require File.dirname(__FILE__) + "/gruff_test_case"
 class TestBezier < GruffTestCase
 
   def setup
-    @data_args = [75, 100, {
-      target: 80,
-      low: 50,
-      high: 90
-    }]
+    @data_args = [
+      75,
+      100,
+      {
+        target: 80,
+        low: 50,
+        high: 90
+      }
+    ]
   end
 
   def test_bezier

--- a/test/test_bullet.rb
+++ b/test/test_bullet.rb
@@ -3,11 +3,15 @@ require File.dirname(__FILE__) + "/gruff_test_case"
 class TestGruffBullet < GruffTestCase
 
   def setup
-    @data_args = [75, 100, {
-      target: 80,
-      low: 50,
-      high: 90
-    }]
+    @data_args = [
+      75,
+      100,
+      {
+        target: 80,
+        low: 50,
+        high: 90
+      }
+    ]
   end
 
   def test_bullet_graph

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -174,9 +174,20 @@ class TestGruffSpider < GruffTestCase
 
   def test_lots_of_data
     g = Gruff::Spider.new(10)
-    @datasets = [[:a, [1]], [:b, [5]], [:c, [3]], [:d, [9]], [:e, [4]],
-                 [:f, [7]], [:g, [0]], [:h, [4]], [:i, [6]], [:j, [0]],
-                 [:k, [4]], [:l, [8]]]
+    @datasets = [
+      [:a, [1]],
+      [:b, [5]],
+      [:c, [3]],
+      [:d, [9]],
+      [:e, [4]],
+      [:f, [7]],
+      [:g, [0]],
+      [:h, [4]],
+      [:i, [6]],
+      [:j, [0]],
+      [:k, [4]],
+      [:l, [8]]
+    ]
 
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -188,9 +199,20 @@ class TestGruffSpider < GruffTestCase
 
   def test_lots_of_data_with_large_names
     g = Gruff::Spider.new(10)
-    @datasets = [[:anteaters, [1]], [:bulls, [5]], [:cats, [3]], [:dogs, [9]], [:elephants, [4]],
-                 [:frogs, [7]], [:giraffes, [0]], [:hamsters, [4]], [:iguanas, [6]],
-                 [:jaguar, [0]], [:kangaroo, [4]], [:locust, [8]]]
+    @datasets = [
+      [:anteaters, [1]],
+      [:bulls, [5]],
+      [:cats, [3]],
+      [:dogs, [9]],
+      [:elephants, [4]],
+      [:frogs, [7]],
+      [:giraffes, [0]],
+      [:hamsters, [4]],
+      [:iguanas, [6]],
+      [:jaguar, [0]],
+      [:kangaroo, [4]],
+      [:locust, [8]]
+    ]
 
     @datasets.each do |data|
       g.data(data[0], data[1])


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/MultilineArrayLineBreaks --auto-correct