### PR TITLE
Rubocop: Fix alignment of multiline array

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -87,15 +87,6 @@ Layout/FirstArgumentIndentation:
   Exclude:
     - 'lib/gruff/mini/legend.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-Layout/FirstArrayElementLineBreak:
-  Exclude:
-    - 'test/test_bezier.rb'
-    - 'test/test_bullet.rb'
-    - 'test/test_legend.rb'
-    - 'test/test_spider.rb'
-
 # Offense count: 22
 # Cop supports --auto-correct.
 Layout/FirstMethodArgumentLineBreak:

--- a/test/test_legend.rb
+++ b/test/test_legend.rb
@@ -56,13 +56,16 @@ class TestGruffLegend < GruffTestCase
   end
 
   def test_more_than_two_lines_of_legends
-    @datasets = @datasets + [[:Julie2, [22, 29, 35, 38, 36, 40, 46, 57]],
-                             [:Jane2, [95, 95, 95, 90, 85, 80, 88, 100]],
-                             [:Philip2, [90, 34, 23, 12, 78, 89, 98, 88]],
-                             [:Arthur2, [5, 10, 13, 11, 6, 16, 22, 32]],
-                             [:Vincent2, [5, 10, 13, 11, 6, 16, 22, 32]],
-                             [:Jake2, [5, 10, 13, 11, 6, 16, 22, 32]],
-                             [:Stephen2, [5, 10, 13, 11, 6, 16, 22, 32]]]
+    data = [
+      [:Julie2, [22, 29, 35, 38, 36, 40, 46, 57]],
+      [:Jane2, [95, 95, 95, 90, 85, 80, 88, 100]],
+      [:Philip2, [90, 34, 23, 12, 78, 89, 98, 88]],
+      [:Arthur2, [5, 10, 13, 11, 6, 16, 22, 32]],
+      [:Vincent2, [5, 10, 13, 11, 6, 16, 22, 32]],
+      [:Jake2, [5, 10, 13, 11, 6, 16, 22, 32]],
+      [:Stephen2, [5, 10, 13, 11, 6, 16, 22, 32]]
+    ]
+    @datasets = @datasets + data
     full_suite_for(:bar2, Gruff::Bar)
   end
 end


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/FirstArrayElementLineBreak --auto-correct