### PR TITLE
Rubocop: Fix alignment of multiline hash

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -135,12 +135,6 @@ Layout/MultilineAssignmentLayout:
     - 'lib/gruff/scene.rb'
     - 'test/test_scatter.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-Layout/MultilineHashKeyLineBreaks:
-  Exclude:
-    - 'Rakefile'
-
 # Offense count: 50
 # Cop supports --auto-correct.
 Layout/MultilineMethodArgumentLineBreaks:

--- a/Rakefile
+++ b/Rakefile
@@ -197,9 +197,14 @@ def get_github_issues
   milestone_description = issues[0] ? issues[0]['milestone']['description'] : "No issues for milestone #{milestone}"
   milestone_description = milestone_description.split("\r\n").map { |l| wrap l }.join("\r\n")
   categories = {
-    'Features' => 'feature', 'Bugfixes' => 'bug', 'Support' => 'support',
-    'Documentation' => 'documentation', 'Pull requests' => nil,
-    'Internal' => 'internal', 'Rejected' => 'rejected', 'Other' => nil
+    'Features' => 'feature',
+    'Bugfixes' => 'bug',
+    'Support' => 'support',
+    'Documentation' => 'documentation',
+    'Pull requests' => nil,
+    'Internal' => 'internal',
+    'Rejected' => 'rejected',
+    'Other' => nil
   }
   grouped_issues = issues.group_by do |i|
     labels = i['labels'].map { |l| l['name'] }


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/MultilineHashKeyLineBreaks --auto-correct