### PR TITLE
Rubocop: Use self-assignment shorthand +=

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -824,12 +824,6 @@ Style/ReturnNil:
     - 'test/image_compare.rb'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Style/SelfAssignment:
-  Exclude:
-    - 'test/test_legend.rb'
-
-# Offense count: 1
 Style/Send:
   Exclude:
     - 'lib/gruff/stacked_area.rb'

--- a/test/test_legend.rb
+++ b/test/test_legend.rb
@@ -65,7 +65,7 @@ class TestGruffLegend < GruffTestCase
       [:Jake2, [5, 10, 13, 11, 6, 16, 22, 32]],
       [:Stephen2, [5, 10, 13, 11, 6, 16, 22, 32]]
     ]
-    @datasets = @datasets + data
+    @datasets += data
     full_suite_for(:bar2, Gruff::Bar)
   end
 end


### PR DESCRIPTION
$ bundle exec rubocop --only Style/SelfAssignment --auto-correct