### PR TITLE
Rubocop: Remove space inside Range literal

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -150,12 +150,6 @@ Layout/MultilineOperationIndentation:
     - 'lib/gruff/line.rb'
     - 'lib/gruff/net.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Layout/SpaceInsideRangeLiteral:
-  Exclude:
-    - 'lib/gruff/base.rb'
-
 # Offense count: 1
 Lint/AmbiguousBlockAssociation:
   Exclude:

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -844,10 +844,10 @@ module Gruff
           if @label_truncation_style == :trailing_dots
             if @label_max_size > 3
               # 4 because '...' takes up 3 chars
-              label_text = "#{label_text[0 .. (@label_max_size - 4)]}..."
+              label_text = "#{label_text[0..(@label_max_size - 4)]}..."
             end
           else # @label_truncation_style is :absolute (default)
-            label_text = label_text[0 .. (@label_max_size - 1)]
+            label_text = label_text[0..(@label_max_size - 1)]
           end
 
         end


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/SpaceInsideRangeLiteral --auto-correct