### PR TITLE
Rubocop: Remove redundant conditional

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -765,12 +765,6 @@ Style/PreferredHashMethods:
 
 # Offense count: 1
 # Cop supports --auto-correct.
-Style/RedundantConditional:
-  Exclude:
-    - 'lib/gruff/bar.rb'
-
-# Offense count: 1
-# Cop supports --auto-correct.
 Style/RedundantParentheses:
   Exclude:
     - 'lib/gruff/side_bar.rb'

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -15,7 +15,7 @@ class Gruff::Bar < Gruff::Base
     # Labels will be centered over the left of the bar if
     # there are more labels than columns. This is basically the same
     # as where it would be for a line graph.
-    @center_labels_over_point = (@labels.keys.length > @column_count ? true : false)
+    @center_labels_over_point = (@labels.keys.length > @column_count)
 
     super
     return unless @has_data


### PR DESCRIPTION
$ bundle exec rubocop --only Style/RedundantConditional --auto-correct