### PR TITLE
Rubocop: Fix argument alignment

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,15 +21,6 @@ Gemspec/RequiredRubyVersion:
   Exclude:
     - 'gruff.gemspec'
 
-# Offense count: 6
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: with_first_argument, with_fixed_indentation
-Layout/ArgumentAlignment:
-  Exclude:
-    - 'lib/gruff/scatter.rb'
-    - 'lib/gruff/spider.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: Categories, ExpectedOrder.

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -275,9 +275,9 @@ protected
         @d.gravity = NorthGravity
         @d.rotation = -90.0 if @use_vertical_x_labels
         @d = @d.annotate_scaled(@base_image,
-                          1.0, 1.0,
-                          x_offset, y_offset,
-                          vertical_label(marker_label, @x_increment), @scale)
+                                1.0, 1.0,
+                                x_offset, y_offset,
+                                vertical_label(marker_label, @x_increment), @scale)
         @d.rotation = 90.0 if @use_vertical_x_labels
       end
     end

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -73,9 +73,9 @@ private
     @d.font_weight = BoldWeight
     @d.gravity = CenterGravity
     @d.annotate_scaled(@base_image,
-                      0, 0,
-                      x, y,
-                      amount, @scale)
+                       0, 0,
+                       x, y,
+                       amount, @scale)
   end
 
   def draw_axes(center_x, center_y, radius, additive_angle, line_color = nil)


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/ArgumentAlignment --auto-correct