### PR TITLE
Rubocop: Use reject instead of inverting select

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -569,13 +569,6 @@ Style/ImplicitRuntimeError:
 Style/InlineComment:
   Enabled: false
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: InverseMethods, InverseBlocks.
-Style/InverseMethods:
-  Exclude:
-    - 'lib/gruff/scene.rb'
-
 # Offense count: 255
 # Cop supports --auto-correct.
 # Configuration parameters: IgnoreMacros, IgnoredMethods, IgnoredPatterns, IncludedMacros, AllowParenthesesInMultilineCall, AllowParenthesesInChaining, AllowParenthesesInCamelCaseMethod, EnforcedStyle.

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -55,7 +55,7 @@ class Gruff::Scene < Gruff::Base
 
   def draw
     # Join all the custom paths and filter out the empty ones
-    image_paths = @layers.map { |layer| layer.path }.select { |path| !path.empty? }
+    image_paths = @layers.map { |layer| layer.path }.reject { |path| path.empty? }
     images = Magick::ImageList.new(*image_paths)
     @base_image = images.flatten_images
   end


### PR DESCRIPTION
$ bundle exec rubocop --only Style/InverseMethods --auto-correct