### PR TITLE
Rubocop: Fix percent literal delimiters

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -723,23 +723,6 @@ Style/OptionHash:
     - 'lib/gruff/bullet.rb'
     - 'test/test_pie.rb'
 
-# Offense count: 38
-# Cop supports --auto-correct.
-# Configuration parameters: PreferredDelimiters.
-Style/PercentLiteralDelimiters:
-  Exclude:
-    - 'Rakefile'
-    - 'gruff.gemspec'
-    - 'lib/gruff.rb'
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/themes.rb'
-    - 'test/test_area.rb'
-    - 'test/test_bar.rb'
-    - 'test/test_dot.rb'
-    - 'test/test_line.rb'
-    - 'test/test_net.rb'
-    - 'test/test_scene.rb'
-
 # Offense count: 4
 # Cop supports --auto-correct.
 Style/PerlBackrefs:

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rake/clean'
 
-CLEAN.concat %w(pkg test/output/*)
+CLEAN.concat %w[pkg test/output/*]
 
 desc 'Run tests'
 task default: :test
@@ -40,7 +40,7 @@ New in version #{milestone_name}:
 
 #{(categories.keys & grouped_issues.keys).map do |cat|
     "#{cat}:\n
-#{grouped_issues[cat].map { |i| wrap(%Q{* Issue ##{i['number']} #{i['title']}}, 2) }.join("\n")}
+#{grouped_issues[cat].map { |i| wrap(%Q(* Issue ##{i['number']} #{i['title']}), 2) }.join("\n")}
     "
   end.join("\n")}
 You can find a complete list of issues here:
@@ -90,7 +90,7 @@ task :stats do
   counts_per_month = Hash.new { |h, k| h[k] = Hash.new { |mh, mk| mh[mk] = 0 } }
   total = 0
 
-  %w{gruff}.each do |gem|
+  %w[gruff].each do |gem|
     versions_uri = URI("#{base_uri}/versions/#{gem}.yaml")
     req = Net::HTTP::Get.new(versions_uri.request_uri)
     res = https.start { |http| http.request(req) }

--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -5,16 +5,16 @@ require 'date'
 require 'gruff/version'
 
 Gem::Specification.new do |s|
-  s.name = %q{gruff}
+  s.name = %q(gruff)
   s.version = Gruff::VERSION
   s.authors = ['Geoffrey Grosenbach', 'Uwe Kubosch']
   s.date = Date.today.to_s
-  s.description = %q{Beautiful graphs for one or multiple datasets. Can be used on websites or in documents.}
-  s.email = %q{boss@topfunky.com}
+  s.description = %q(Beautiful graphs for one or multiple datasets. Can be used on websites or in documents.)
+  s.email = %q(boss@topfunky.com)
   s.files = `git ls-files`.split($/).reject { |f| f =~ /^test#{File::ALT_SEPARATOR || File::SEPARATOR}output/ }
-  s.homepage = %q{https://github.com/topfunky/gruff}
-  s.require_paths = %w(lib)
-  s.summary = %q{Beautiful graphs for one or multiple datasets.}
+  s.homepage = %q(https://github.com/topfunky/gruff)
+  s.require_paths = %w[lib]
+  s.summary = %q(Beautiful graphs for one or multiple datasets.)
   s.license = 'MIT'
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
   s.executables = s.files.grep(%r{^bin/}).map { |f| File.basename(f) }

--- a/lib/gruff.rb
+++ b/lib/gruff.rb
@@ -2,7 +2,7 @@ require 'gruff/version'
 
 # Extra full path added to fix loading errors on some installations.
 
-%w(
+%w[
   themes
   base
   area
@@ -27,6 +27,6 @@ require 'gruff/version'
   mini/bar
   mini/pie
   mini/side_bar
-).each do |filename|
+].each do |filename|
   require "gruff/#{filename}"
 end

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -348,7 +348,7 @@ module Gruff
       reset_themes
 
       defaults = {
-        colors: %w(black white),
+        colors: %w[black white],
         additional_line_colors: [],
         marker_color: 'white',
         marker_shadow_color: nil,

--- a/lib/gruff/themes.rb
+++ b/lib/gruff/themes.rb
@@ -14,7 +14,7 @@ module Gruff
       ],
       marker_color: 'white',
       font_color: 'white',
-      background_colors: %w(black #4a465a)
+      background_colors: %w[black #4a465a]
     }
 
     # A color scheme plucked from the colors on the popular usability blog.
@@ -30,7 +30,7 @@ module Gruff
       ],
       marker_color: 'black',
       font_color: 'black',
-      background_colors: %w(#d1edf5 white)
+      background_colors: %w[#d1edf5 white]
     }
 
     # A color scheme from the colors used on the 2005 Rails keynote
@@ -47,7 +47,7 @@ module Gruff
       ],
       marker_color: 'white',
       font_color: 'white',
-      background_colors: %w(#0083a3 #0083a3)
+      background_colors: %w[#0083a3 #0083a3]
     }
 
     # A color scheme similar to that used on the popular podcast site.
@@ -63,7 +63,7 @@ module Gruff
       ],
       marker_color: 'white',
       font_color: 'white',
-      background_colors: %w(#ff47a4 #ff1f81)
+      background_colors: %w[#ff47a4 #ff1f81]
     }
 
     # A pastel theme

--- a/test/test_area.rb
+++ b/test/test_area.rb
@@ -86,7 +86,7 @@ class TestGruffArea < GruffTestCase
       40 => '6/4',
       50 => '6/16'
     }
-    %w{jimmy jane philip arthur julie bert}.each do |student_name|
+    %w[jimmy jane philip arthur julie bert].each do |student_name|
       g.data(student_name, (0..50).collect { |i| rand 100 })
     end
 
@@ -105,7 +105,7 @@ class TestGruffArea < GruffTestCase
       40 => '6/4',
       50 => '6/16'
     }
-    %w{jimmy jane philip arthur julie bert}.each do |student_name|
+    %w[jimmy jane philip arthur julie bert].each do |student_name|
       g.data(student_name, (0..50).collect { |i| rand 100 })
     end
 

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -271,7 +271,7 @@ class TestGruffBar < GruffTestCase
     g.legend_font_size = 32
     g.marker_font_size = 32
     g.theme = {
-      colors: %w(#efd250 #666699 #e5573f #9595e2),
+      colors: %w[#efd250 #666699 #e5573f #9595e2],
       marker_color: 'white',
       font_color: 'blue',
       background_image: 'assets/pc306715.jpg'
@@ -294,7 +294,7 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient top to bottom'
     g.theme = {
-      background_colors: %w(#ff0000 #00ff00),
+      background_colors: %w[#ff0000 #00ff00],
       background_direction: :top_bottom,
     }
     g.labels = @labels
@@ -309,7 +309,7 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient top to bottom'
     g.theme = {
-      background_colors: %w(#ff0000 #00ff00),
+      background_colors: %w[#ff0000 #00ff00],
       background_direction: :bottom_top,
     }
     g.labels = @labels
@@ -324,7 +324,7 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient left to right'
     g.theme = {
-      background_colors: %w(#ff0000 #00ff00),
+      background_colors: %w[#ff0000 #00ff00],
       background_direction: :left_right,
     }
     g.labels = @labels
@@ -339,7 +339,7 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient right to left'
     g.theme = {
-      background_colors: %w(#ff0000 #00ff00),
+      background_colors: %w[#ff0000 #00ff00],
       background_direction: :right_left,
     }
     g.labels = @labels
@@ -354,7 +354,7 @@ class TestGruffBar < GruffTestCase
     g = Gruff::Bar.new
     g.title = 'Background gradient top left to bottom right'
     g.theme = {
-      background_colors: %w(#ff0000 #00ff00),
+      background_colors: %w[#ff0000 #00ff00],
       background_direction: :topleft_bottomright,
     }
     g.labels = @labels
@@ -370,7 +370,7 @@ class TestGruffBar < GruffTestCase
     g.title = 'Background gradient top right to bottom left'
     g.title_font_size = 30
     g.theme = {
-      background_colors: %w(#ff0000 #00ff00),
+      background_colors: %w[#ff0000 #00ff00],
       background_direction: :topright_bottomleft,
     }
     g.labels = @labels

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -204,7 +204,7 @@ class TestGruffDot < GruffTestCase
     g.legend_font_size = 32
     g.marker_font_size = 32
     g.theme = {
-      colors: %w(#efd250 #666699 #e5573f #9595e2),
+      colors: %w[#efd250 #666699 #e5573f #9595e2],
       marker_color: 'white',
       font_color: 'blue',
       background_image: 'assets/pc306715.jpg'

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -7,7 +7,7 @@ class TestGruffLine < GruffTestCase
     g = Gruff::Line.new(400)
     g.title = 'Transparent Background'
     g.theme = {
-      colors: %w(black grey),
+      colors: %w[black grey],
       marker_color: 'grey',
       font_color: 'black',
       background_colors: 'transparent'
@@ -206,7 +206,7 @@ class TestGruffLine < GruffTestCase
   end
 
   def test_similar_high_end_values
-    @dataset = %w(29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828).collect { |i| i.to_f }
+    @dataset = %w[29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828].collect { |i| i.to_f }
 
     g = Gruff::Line.new
     g.title = 'Similar High End Values Test'
@@ -232,7 +232,7 @@ class TestGruffLine < GruffTestCase
       40 => '6/4',
       50 => '6/16'
     }
-    %w{jimmy jane philip arthur julie bert}.each do |student_name|
+    %w[jimmy jane philip arthur julie bert].each do |student_name|
       g.data(student_name, (0..50).collect { |i| rand 100 })
     end
 
@@ -251,7 +251,7 @@ class TestGruffLine < GruffTestCase
       40 => '6/4',
       50 => '6/16'
     }
-    %w{jimmy jane philip arthur julie bert}.each do |student_name|
+    %w[jimmy jane philip arthur julie bert].each do |student_name|
       g.data(student_name, (0..50).collect { |i| rand 100 })
     end
 
@@ -520,9 +520,9 @@ class TestGruffLine < GruffTestCase
   def test_jruby_error
     g = Gruff::Line.new
     g.theme = {
-      colors: %w(#7F0099 #2F85ED #2FED09 #EC962F),
+      colors: %w[#7F0099 #2F85ED #2FED09 #EC962F],
       marker_color: '#aaa',
-      background_colors: %w(#E8E8E8 #B9FD6C)
+      background_colors: %w[#E8E8E8 #B9FD6C]
     }
     g.hide_title = true
 

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -104,7 +104,7 @@ class TestGruffNet < GruffTestCase
   def test_similar_high_end_values
     g = Gruff::Net.new
     g.title = "Similar High End Values Test"
-    g.data('similar points', %w(29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828).collect { |i| i.to_f })
+    g.data('similar points', %w[29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828].collect { |i| i.to_f })
 
     # Default theme
     g.write("test/output/net_similar_high_end_values.png")
@@ -121,7 +121,7 @@ class TestGruffNet < GruffTestCase
       40 => '6/4',
       50 => '6/16'
     }
-    %w{jimmy jane philip arthur julie bert}.each do |student_name|
+    %w[jimmy jane philip arthur julie bert].each do |student_name|
       g.data(student_name, (0..50).collect { |i| rand 100 })
     end
 
@@ -140,7 +140,7 @@ class TestGruffNet < GruffTestCase
       40 => '6/4',
       50 => '6/16'
     }
-    %w{jimmy jane philip arthur julie bert}.each do |student_name|
+    %w[jimmy jane philip arthur julie bert].each do |student_name|
       g.data(student_name, (0..50).collect { |i| rand 100 })
     end
 

--- a/test/test_scene.rb
+++ b/test/test_scene.rb
@@ -48,7 +48,7 @@ class TestGruffScene < GruffTestCase
 
   def test_layer
     l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "clouds")
-    assert_equal %w(cloudy.png partly_cloudy.png stormy.png), l.filenames.sort
+    assert_equal %w[cloudy.png partly_cloudy.png stormy.png], l.filenames.sort
 
     l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "grass")
     assert_equal 'default.png', l.selected_filename
@@ -88,9 +88,9 @@ private
 
   def setup_scene
     g = Gruff::Scene.new("500x100", File.expand_path("../assets/city_scene", File.dirname(__FILE__)))
-    g.layers = %w(background haze sky clouds)
-    g.weather_group = %w(clouds)
-    g.time_group = %w(background sky)
+    g.layers = %w[background haze sky clouds]
+    g.weather_group = %w[clouds]
+    g.time_group = %w[background sky]
     g
   end
 


### PR DESCRIPTION
$ bundle exec rubocop --only Style/PercentLiteralDelimiters --auto-correct