### PR TITLE
Test: Require ‘date’ to fix “NameError: uninitialized constant TestGruffScatter::Date” error

### DIFF
--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/ruby
 
 require File.dirname(__FILE__) + '/gruff_test_case'
+require 'date'
 
 class TestGruffScatter < Minitest::Test
 


### PR DESCRIPTION
When run test, it causes following error on my environment:

* OS: macOS 10.15.4
* Ruby: ruby 2.7.1

```
ERROR["test_custom_label_format", #<Minitest::Reporters::Suite:0x00007fa05d7173c0 @name="TestGruffScatter">, 22.75117299996782]
 test_custom_label_format#TestGruffScatter (22.75s)
Minitest::UnexpectedError:         NameError: uninitialized constant TestGruffScatter::Date
        Did you mean?  Data
            /Users/watson/prj/gruff/test/test_scatter.rb:66:in `block in test_custom_label_format'
            /Users/watson/prj/gruff/test/test_scatter.rb:66:in `each'
            /Users/watson/prj/gruff/test/test_scatter.rb:66:in `map'
            /Users/watson/prj/gruff/test/test_scatter.rb:66:in `test_custom_label_format'
```