### PR TITLE
Gemfile: refer to https for rubygems.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'http://rubygems.org'
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in gruff.gemspec
 gemspec


### PR DESCRIPTION
This PR uses `https` to connect to rubygems.org for metadata.