### PR TITLE
Rubocop: Fix indentation of first argument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -70,14 +70,6 @@ Layout/EmptyLinesAroundModuleBody:
     - 'lib/gruff/mini/side_bar.rb'
     - 'lib/gruff/themes.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, IndentationWidth.
-# SupportedStyles: consistent, consistent_relative_to_receiver, special_for_inner_method_call, special_for_inner_method_call_in_parentheses
-Layout/FirstArgumentIndentation:
-  Exclude:
-    - 'lib/gruff/mini/legend.rb'
-
 # Offense count: 22
 # Cop supports --auto-correct.
 Layout/FirstMethodArgumentLineBreak:

--- a/lib/gruff/mini/legend.rb
+++ b/lib/gruff/mini/legend.rb
@@ -18,9 +18,7 @@ module Gruff
 
         @legend_labels = @data.collect { |item| item[Gruff::Base::DATA_LABEL_INDEX] }
 
-        legend_height = scale_fontsize(
-                                       @data.length * calculate_line_height +
-                                       @top_margin + @bottom_margin)
+        legend_height = scale_fontsize(@data.length * calculate_line_height + @top_margin + @bottom_margin)
 
         @original_rows = @raw_rows
         @original_columns = @raw_columns


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/FirstArgumentIndentation --auto-correct