### PR TITLE
Rubocop: Remove blank line around class body

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,13 +49,6 @@ Layout/EmptyLineAfterMagicComment:
   Exclude:
     - 'gruff.gemspec'
 
-# Offense count: 81
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines, beginning_only, ending_only
-Layout/EmptyLinesAroundClassBody:
-  Enabled: false
-
 # Offense count: 15
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle.

--- a/lib/gruff/area.rb
+++ b/lib/gruff/area.rb
@@ -40,5 +40,4 @@ class Gruff::Area < Gruff::Base
 
     @d.draw(@base_image)
   end
-
 end

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -2,7 +2,6 @@ require File.dirname(__FILE__) + '/base'
 require File.dirname(__FILE__) + '/bar_conversion'
 
 class Gruff::Bar < Gruff::Base
-
   # Spacing factor applied between bars
   attr_accessor :bar_spacing
 
@@ -105,5 +104,4 @@ protected
 
     @d.draw(@base_image)
   end
-
 end

--- a/lib/gruff/bar_conversion.rb
+++ b/lib/gruff/bar_conversion.rb
@@ -42,5 +42,4 @@ class Gruff::BarConversion
       result[1] = 0.0
     end
   end
-
 end

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -20,7 +20,6 @@ require File.dirname(__FILE__) + '/deprecated'
 
 module Gruff
   class Base
-
     include Magick
     include Deprecated
 
@@ -1146,7 +1145,6 @@ module Gruff
     def deg2rad(angle)
       angle * (Math::PI / 180.0)
     end
-
   end # Gruff::Base
 
   class IncorrectNumberOfDatasetsException < StandardError
@@ -1157,7 +1155,6 @@ end # Gruff
 module Magick
 
   class Draw
-
     # Additional method to scale annotation text since Draw.scale doesn't.
     def annotate_scaled(img, width, height, x, y, text, scale)
       scaled_width = (width * scale) >= 1 ? (width * scale) : 1
@@ -1180,7 +1177,6 @@ module Magick
       end
       # EMXIF
     end
-
   end
 
 end # Magick

--- a/lib/gruff/bezier.rb
+++ b/lib/gruff/bezier.rb
@@ -41,5 +41,4 @@ class Gruff::Bezier < Gruff::Base
 
     @d.draw(@base_image)
   end
-
 end

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -3,7 +3,6 @@ require 'gruff/themes'
 
 # http://en.wikipedia.org/wiki/Bullet_graph
 class Gruff::Bullet < Gruff::Base
-
   def initialize(target_width = "400x40")
     if not Numeric === target_width
       geometric_width, geometric_height = target_width.split('x')
@@ -104,5 +103,4 @@ class Gruff::Bullet < Gruff::Base
       @base_image, 1.0, 1.0, @font_height / 2, @font_height / 2, @title, @scale
     )
   end
-
 end

--- a/lib/gruff/dot.rb
+++ b/lib/gruff/dot.rb
@@ -5,7 +5,6 @@ require File.dirname(__FILE__) + '/base'
 # see: 'Creating More Effective Graphs' by Robbins
 
 class Gruff::Dot < Gruff::Base
-
   def draw
     @has_left_labels = true
     super
@@ -120,5 +119,4 @@ protected
       @labels_seen[index] = 1
     end
   end
-
 end

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -12,7 +12,6 @@ require File.dirname(__FILE__) + '/base'
 # There are also other options described below, such as #baseline_value, #baseline_color, #hide_dots, and #hide_lines.
 
 class Gruff::Line < Gruff::Base
-
   # Allow for reference lines ( which are like baseline ... just allowing for more & on both axes )
   attr_accessor :reference_lines
   attr_accessor :reference_line_default_color

--- a/lib/gruff/mini/bar.rb
+++ b/lib/gruff/mini/bar.rb
@@ -6,7 +6,6 @@ module Gruff
   module Mini
 
     class Bar < Gruff::Bar
-
       include Gruff::Mini::Legend
 
       def initialize_ivars
@@ -30,7 +29,6 @@ module Gruff
         draw_vertical_legend
         @d.draw(@base_image)
       end
-
     end
 
   end

--- a/lib/gruff/mini/pie.rb
+++ b/lib/gruff/mini/pie.rb
@@ -6,7 +6,6 @@ module Gruff
   module Mini
 
     class Pie < Gruff::Pie
-
       include Gruff::Mini::Legend
 
       def initialize_ivars
@@ -29,7 +28,6 @@ module Gruff
 
         @d.draw(@base_image)
       end # def draw
-
     end # class Pie
 
   end

--- a/lib/gruff/mini/side_bar.rb
+++ b/lib/gruff/mini/side_bar.rb
@@ -6,7 +6,6 @@ module Gruff
   module Mini
 
     class SideBar < Gruff::SideBar
-
       include Gruff::Mini::Legend
 
       def initialize_ivars
@@ -28,7 +27,6 @@ module Gruff
 
         @d.draw(@base_image)
       end
-
     end
 
   end

--- a/lib/gruff/net.rb
+++ b/lib/gruff/net.rb
@@ -2,7 +2,6 @@ require File.dirname(__FILE__) + '/base'
 
 # Experimental!!! See also the Spider graph.
 class Gruff::Net < Gruff::Base
-
   # Hide parts of the graph to fit more datapoints, or for a different appearance.
   attr_accessor :hide_dots
 
@@ -117,5 +116,4 @@ private
     @d.gravity = CenterGravity
     @d.annotate_scaled(@base_image, 0, 0, x, y, amount, @scale)
   end
-
 end

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -5,7 +5,6 @@ require File.dirname(__FILE__) + '/base'
 # Doesn't work yet.
 #
 class Gruff::PhotoBar < Gruff::Base
-
 # TODO
 #
 # define base and cap in yml
@@ -93,5 +92,4 @@ protected
     end
     @colors = color_list
   end
-
 end

--- a/lib/gruff/pie.rb
+++ b/lib/gruff/pie.rb
@@ -12,7 +12,6 @@ require File.dirname(__FILE__) + '/base'
 # To control where the pie chart starts creating slices, use #zero_degree.
 
 class Gruff::Pie < Gruff::Base
-
   DEFAULT_TEXT_OFFSET_PERCENTAGE = 0.15
 
   # Can be used to make the pie start cutting slices at the top (-90.0)

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -9,7 +9,6 @@ require File.dirname(__FILE__) + '/base'
 #
 #
 class Gruff::Scatter < Gruff::Base
-
   # Maximum X Value. The value will get overwritten by the max in the
   # datasets.
   attr_accessor :maximum_x_value
@@ -306,5 +305,4 @@ private
   def get_x_coord(x_data_point, width, offset) #:nodoc:
     x_data_point * width + offset
   end
-
 end # end Gruff::Scatter

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -39,7 +39,6 @@ require File.dirname(__FILE__) + '/base'
 # * If there is a file named 'default.png', it will be used unless other input values are set for the corresponding layer.
 
 class Gruff::Scene < Gruff::Base
-
   # An array listing the foldernames that will be rendered, from back to front.
   #
   #  g.layers = %w(sky clouds buildings street people)
@@ -101,11 +100,9 @@ private
       end
     end
   end
-
 end
 
 class Gruff::Group
-
   include Observable
   attr_reader :name
 
@@ -120,11 +117,9 @@ class Gruff::Group
     changed
     notify_observers value
   end
-
 end
 
 class Gruff::Layer
-
   attr_reader :name
 
   def initialize(base_dir, folder_name)
@@ -203,5 +198,4 @@ private
   def file_exists_or_blank(filename)
     @filenames.include?("#{filename}.png") ? "#{filename}.png" : select_default
   end
-
 end

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -4,7 +4,6 @@ require File.dirname(__FILE__) + '/base'
 # Graph with individual horizontal bars instead of vertical bars.
 
 class Gruff::SideBar < Gruff::Base
-
   # Spacing factor applied between bars
   attr_accessor :bar_spacing
 
@@ -131,5 +130,4 @@ protected
       @labels_seen[index] = 1
     end
   end
-
 end

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -91,5 +91,4 @@ protected
   def max(data_point, index)
     @data.reduce(0) { |sum, item| sum + item.points[index] }
   end
-
 end

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -4,7 +4,6 @@ require File.dirname(__FILE__) + '/base'
 #
 # Submitted by Kevin Clark http://glu.ttono.us/
 class Gruff::Spider < Gruff::Base
-
   # Hide all text
   attr_reader :hide_text
   attr_accessor :hide_axes
@@ -120,5 +119,4 @@ private
   def sums_for_spider
     @data.reduce(0.0) { |sum, data_row| sum + data_row.points.first }
   end
-
 end

--- a/lib/gruff/stacked_area.rb
+++ b/lib/gruff/stacked_area.rb
@@ -59,5 +59,4 @@ class Gruff::StackedArea < Gruff::Base
 
     @d.draw(@base_image)
   end
-
 end

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -55,5 +55,4 @@ class Gruff::StackedBar < Gruff::Base
 
     @d.draw(@base_image)
   end
-
 end

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -153,5 +153,4 @@ protected
     end
     g
   end
-
 end

--- a/test/test_accumulator_bar.rb
+++ b/test/test_accumulator_bar.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffAccumulatorBar < GruffTestCase
-
   # TODO Delete old output files once when starting tests
 
   def setup
@@ -47,5 +46,4 @@ class TestGruffAccumulatorBar < GruffTestCase
       g.write('test/output/_SHOULD_NOT_ACTUALLY_BE_WRITTEN.png')
     }
   end
-
 end

--- a/test/test_area.rb
+++ b/test/test_area.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffArea < GruffTestCase
-
   def setup
     super
     @datasets = [
@@ -130,5 +129,4 @@ protected
     end
     return g
   end
-
 end

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffBar < GruffTestCase
-
   # TODO Delete old output files once when starting tests
 
   def setup

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffBase < GruffTestCase
-
   def setup
     @sample_numeric_labels = {
       0 => 6,

--- a/test/test_bezier.rb
+++ b/test/test_bezier.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestBezier < GruffTestCase
-
   def setup
     @data_args = [
       75,

--- a/test/test_bullet.rb
+++ b/test/test_bullet.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffBullet < GruffTestCase
-
   def setup
     @data_args = [
       75,
@@ -58,5 +57,4 @@ class TestGruffBullet < GruffTestCase
     )
     g.write("test/output/bullet_no_options.png")
   end
-
 end

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffDot < GruffTestCase
-
   # TODO Delete old output files once when starting tests
 
   def setup
@@ -251,5 +250,4 @@ protected
     end
     g
   end
-
 end

--- a/test/test_labels_for_null_data.rb
+++ b/test/test_labels_for_null_data.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestLabelsForNullData < GruffTestCase
-
   def setup
     @dataset = [nil, 1, 2, 1, nil]
 
@@ -23,5 +22,4 @@ class TestLabelsForNullData < GruffTestCase
 
     g.write("test/output/TestLabelsForNullData.png")
   end
-
 end

--- a/test/test_legend.rb
+++ b/test/test_legend.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffLegend < GruffTestCase
-
   def setup
     @datasets = [
       [:Jimmy, [25, 36, 86, 39, 25, 31, 79, 88]],

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -694,5 +694,4 @@ private
     g.data(:peaches, [-10, -8, -6, -3])
     g
   end
-
 end

--- a/test/test_mini_bar.rb
+++ b/test/test_mini_bar.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../gruff_test_case', __FILE__)
 
 class TestMiniBar < GruffTestCase
-
   def test_simple_bar
     setup_single_dataset
     g = setup_basic_graph(Gruff::Mini::Bar, 200)
@@ -28,5 +27,4 @@ class TestMiniBar < GruffTestCase
   #   g.data "Music", 16
   #   g.write "mini_bar_many_colors.png"
   # end
-
 end

--- a/test/test_mini_pie.rb
+++ b/test/test_mini_pie.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../gruff_test_case', __FILE__)
 
 class TestMiniPie < GruffTestCase
-
   def test_simple_pie
     g = setup_basic_graph(Gruff::Mini::Pie, 200)
     write_test_file g, 'mini_pie.png'
@@ -21,5 +20,4 @@ class TestMiniPie < GruffTestCase
   #   g.data "Music", 16
   #   g.write "mini_pie.png"
   # end
-
 end

--- a/test/test_mini_side_bar.rb
+++ b/test/test_mini_side_bar.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../gruff_test_case', __FILE__)
 
 class TestMiniSideBar < GruffTestCase
-
   def test_one_color
     # Use a single data set
     @datasets = [
@@ -32,5 +31,4 @@ class TestMiniSideBar < GruffTestCase
     g = setup_basic_graph(Gruff::Mini::SideBar, 200)
     write_test_file g, 'mini_side_bar_multi_color.png'
   end
-
 end

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffNet < GruffTestCase
-
   def setup
     super
     @datasets = [
@@ -224,5 +223,4 @@ protected
     end
     return g
   end
-
 end

--- a/test/test_photo.rb
+++ b/test/test_photo.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffPhotoBar < GruffTestCase
-
 #   def setup
 #     @datasets = [
 #       [:Jimmy, [25, 36, 86, 39]],
@@ -37,5 +36,4 @@ class TestGruffPhotoBar < GruffTestCase
 #
 #     g.write("test/output/photo_plastik_#{size}.png")
 #   end
-
 end

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffPie < GruffTestCase
-
   def setup
     @datasets = [
       [:Darren, [25]],

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -4,7 +4,6 @@ require File.dirname(__FILE__) + '/gruff_test_case'
 require 'date'
 
 class TestGruffScatter < Minitest::Test
-
   def setup
     @datasets = [
       [:Chuck, [20, 10, 5, 12, 11, 6, 10, 7], [5, 10, 19, 6, 9, 1, 14, 8]],
@@ -269,5 +268,4 @@ protected
     g.data(:peaches, [-10, -8, -6, -3], [-1, -1, -3, -3])
     g
   end
-
 end # end GruffTestCase

--- a/test/test_scene.rb
+++ b/test/test_scene.rb
@@ -6,7 +6,6 @@ require 'yaml'
 class LayerStub < Gruff::Layer; attr_reader :base_dir, :filenames, :selected_filename; end
 
 class TestGruffScene < GruffTestCase
-
   def test_hazy
     g = setup_scene
     g.weather = "cloudy"
@@ -93,5 +92,4 @@ private
     g.time_group = %w[background sky]
     g
   end
-
 end

--- a/test/test_side_bar.rb
+++ b/test/test_side_bar.rb
@@ -1,7 +1,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffSideBar < GruffTestCase
-
   def test_bar_graph
     g = setup_basic_graph(Gruff::SideBar, 800)
     write_test_file g, 'side_bar.png'
@@ -50,5 +49,4 @@ class TestGruffSideBar < GruffTestCase
     g.show_labels_for_bar_values = true
     g.write("test/output/side_bar_labels.png")
   end
-
 end

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffSideStackedBar < GruffTestCase
-
   def setup
     @datasets = [
       [:Jimmy, [25, 36, 86, 39]],
@@ -98,5 +97,4 @@ protected
     end
     return g
   end
-
 end

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffSpider < GruffTestCase
-
   def setup
     @datasets = [
       [:Strength, [10]],
@@ -275,5 +274,4 @@ protected
     end
     return g
   end
-
 end

--- a/test/test_stacked_area.rb
+++ b/test/test_stacked_area.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffStackedArea < GruffTestCase
-
   def setup
     @datasets = [
       [:Jimmy, [25, 36, 86, 39]],
@@ -46,5 +45,4 @@ class TestGruffStackedArea < GruffTestCase
     end
     g.write 'test/output/stacked_area_keynote_small.png'
   end
-
 end

--- a/test/test_stacked_bar.rb
+++ b/test/test_stacked_bar.rb
@@ -3,7 +3,6 @@
 require File.dirname(__FILE__) + "/gruff_test_case"
 
 class TestGruffStackedBar < GruffTestCase
-
   def setup
     @datasets = [
       [:Jimmy, [25, 36, 86, 39]],
@@ -62,5 +61,4 @@ class TestGruffStackedBar < GruffTestCase
     end
     g.write "test/output/stacked_bar_keynote_no_space.png"
   end
-
 end


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/EmptyLinesAroundClassBody --auto-correct