### PR TITLE
Rubocop: Remove blank line around module body

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,20 +49,6 @@ Layout/EmptyLineAfterMagicComment:
   Exclude:
     - 'gruff.gemspec'
 
-# Offense count: 15
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: empty_lines, empty_lines_except_namespace, empty_lines_special, no_empty_lines
-Layout/EmptyLinesAroundModuleBody:
-  Exclude:
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/deprecated.rb'
-    - 'lib/gruff/mini/bar.rb'
-    - 'lib/gruff/mini/legend.rb'
-    - 'lib/gruff/mini/pie.rb'
-    - 'lib/gruff/mini/side_bar.rb'
-    - 'lib/gruff/themes.rb'
-
 # Offense count: 22
 # Cop supports --auto-correct.
 Layout/FirstMethodArgumentLineBreak:

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1149,11 +1149,9 @@ module Gruff
 
   class IncorrectNumberOfDatasetsException < StandardError
   end
-
 end # Gruff
 
 module Magick
-
   class Draw
     # Additional method to scale annotation text since Draw.scale doesn't.
     def annotate_scaled(img, width, height, x, y, text, scale)
@@ -1178,7 +1176,6 @@ module Magick
       # EMXIF
     end
   end
-
 end # Magick
 
 class String

--- a/lib/gruff/deprecated.rb
+++ b/lib/gruff/deprecated.rb
@@ -4,7 +4,6 @@
 
 module Gruff
   module Deprecated
-
     def scale_measurements
       setup_graph_measurements
     end
@@ -33,6 +32,5 @@ module Gruff
     # def setup_graph_height
     #   @graph_height = @graph_bottom - @graph_top
     # end
-
   end
 end

--- a/lib/gruff/mini/bar.rb
+++ b/lib/gruff/mini/bar.rb
@@ -4,7 +4,6 @@
 #
 module Gruff
   module Mini
-
     class Bar < Gruff::Bar
       include Gruff::Mini::Legend
 
@@ -30,6 +29,5 @@ module Gruff
         @d.draw(@base_image)
       end
     end
-
   end
 end

--- a/lib/gruff/mini/legend.rb
+++ b/lib/gruff/mini/legend.rb
@@ -1,7 +1,6 @@
 module Gruff
   module Mini
     module Legend
-
       attr_accessor :hide_mini_legend, :legend_position
 
       def initialize(*)
@@ -105,7 +104,6 @@ module Gruff
         end
         truncated_label + (truncated_label.length < label.to_s.length ? "..." : '')
       end
-
     end
   end
 end

--- a/lib/gruff/mini/pie.rb
+++ b/lib/gruff/mini/pie.rb
@@ -4,7 +4,6 @@
 #
 module Gruff
   module Mini
-
     class Pie < Gruff::Pie
       include Gruff::Mini::Legend
 
@@ -29,6 +28,5 @@ module Gruff
         @d.draw(@base_image)
       end # def draw
     end # class Pie
-
   end
 end

--- a/lib/gruff/mini/side_bar.rb
+++ b/lib/gruff/mini/side_bar.rb
@@ -4,7 +4,6 @@
 #
 module Gruff
   module Mini
-
     class SideBar < Gruff::SideBar
       include Gruff::Mini::Legend
 
@@ -28,6 +27,5 @@ module Gruff
         @d.draw(@base_image)
       end
     end
-
   end
 end

--- a/lib/gruff/themes.rb
+++ b/lib/gruff/themes.rb
@@ -1,6 +1,5 @@
 module Gruff
   module Themes
-
     # A color scheme similar to the popular presentation software.
     KEYNOTE = {
       colors: [
@@ -96,6 +95,5 @@ module Gruff
       font_color: 'black',
       background_colors: 'white'
     }
-
   end
 end


### PR DESCRIPTION
$ bundle exec rubocop --only Layout/EmptyLinesAroundModuleBody --auto-correct