### PR TITLE
Rubocop: Remove redundant self

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -605,14 +605,6 @@ Style/RedundantReturn:
     - 'test/test_sidestacked_bar.rb'
     - 'test/test_spider.rb'
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Style/RedundantSelf:
-  Exclude:
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/line.rb'
-    - 'lib/gruff/side_bar.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/RedundantSort:

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1158,10 +1158,10 @@ module Magick
       scaled_width = (width * scale) >= 1 ? (width * scale) : 1
       scaled_height = (height * scale) >= 1 ? (height * scale) : 1
 
-      self.annotate(img,
-                    scaled_width, scaled_height,
-                    x * scale, y * scale,
-                    text.gsub('%', '%%'))
+      annotate(img,
+               scaled_width, scaled_height,
+               x * scale, y * scale,
+               text.gsub('%', '%%'))
     end
 
     if defined? JRUBY_VERSION
@@ -1181,6 +1181,6 @@ end # Magick
 class String
   #Taken from http://codesnippets.joyent.com/posts/show/330
   def commify(delimiter = ',')
-    self.gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{delimiter}")
+    gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1#{delimiter}")
   end
 end

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -140,7 +140,7 @@ class Gruff::Line < Gruff::Base
     raise ArgumentError, 'x_data_points.length != y_data_points.length!' if x_data_points.length != y_data_points.length
 
     # call the existing data routine for the y data.
-    self.data(name, y_data_points, color)
+    data(name, y_data_points, color)
 
     x_data_points = Array(x_data_points) # make sure it's an array
     # append the x data to the last entry that was just added in the @data member

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -33,7 +33,7 @@ protected
     # if we're a side stacked bar then we don't need to draw ourself at all
     # because sometimes (due to different heights/min/max) you can actually
     # see both graphs and it looks like crap
-    return if self.is_a?(Gruff::SideStackedBar)
+    return if is_a?(Gruff::SideStackedBar)
 
     @norm_data.each_with_index do |data_row, row_index|
       @d = @d.fill data_row.color


### PR DESCRIPTION
$ bundle exec rubocop --only Style/RedundantSelf --auto-correct