### PR TITLE
Rubocop: Remove redundant return

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -592,19 +592,6 @@ Style/RedundantPercentQ:
     - 'Rakefile'
     - 'gruff.gemspec'
 
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: AllowMultipleReturnValues.
-Style/RedundantReturn:
-  Exclude:
-    - 'Rakefile'
-    - 'lib/gruff/scene.rb'
-    - 'test/test_area.rb'
-    - 'test/test_net.rb'
-    - 'test/test_pie.rb'
-    - 'test/test_sidestacked_bar.rb'
-    - 'test/test_spider.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/RedundantSort:

--- a/Rakefile
+++ b/Rakefile
@@ -219,7 +219,8 @@ def get_github_issues
     cat ||= 'Other'
     cat
   end
-  return categories, grouped_issues, milestone, milestone_description, milestone_name
+
+  [categories, grouped_issues, milestone, milestone_description, milestone_name]
 end
 
 def wrap(string, indent = 0)

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -180,7 +180,8 @@ private
         return "#{times[index - 1]}.png"
       end
     end
-    return "#{times.last}.png"
+
+    "#{times.last}.png"
   end
 
   # Match "partly cloudy" to "partly_cloudy.png"

--- a/test/test_area.rb
+++ b/test/test_area.rb
@@ -127,6 +127,7 @@ protected
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    return g
+
+    g
   end
 end

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -221,6 +221,7 @@ protected
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    return g
+
+    g
   end
 end

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -163,7 +163,8 @@ protected
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    return g
+
+    g
   end
 
   # Example Gruff::Pie Subclass demonstrating custom labels

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -95,6 +95,7 @@ protected
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    return g
+
+    g
   end
 end

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -272,6 +272,7 @@ protected
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    return g
+
+    g
   end
 end


### PR DESCRIPTION
$ bundle exec rubocop --only Style/RedundantReturn --auto-correct