### PR TITLE
Rubocop: Remove trailing comma in Hash

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -655,24 +655,6 @@ Style/TernaryParentheses:
     - 'lib/gruff/scatter.rb'
     - 'lib/gruff/side_bar.rb'
 
-# Offense count: 43
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyleForMultiline.
-# SupportedStylesForMultiline: comma, consistent_comma, no_comma
-Style/TrailingCommaInHashLiteral:
-  Exclude:
-    - 'test/gruff_test_case.rb'
-    - 'test/test_area.rb'
-    - 'test/test_bar.rb'
-    - 'test/test_base.rb'
-    - 'test/test_dot.rb'
-    - 'test/test_legend.rb'
-    - 'test/test_line.rb'
-    - 'test/test_net.rb'
-    - 'test/test_sidestacked_bar.rb'
-    - 'test/test_stacked_area.rb'
-    - 'test/test_stacked_bar.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: ExactNameMatch, AllowPredicates, AllowDSLWriters, IgnoreClassMethods, AllowedMethods.

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -49,7 +49,7 @@ class GruffTestCase < Minitest::Test
       4 => '6/4',
       5 => '6/12',
       6 => '6/21',
-      7 => '6/28',
+      7 => '6/28'
     }
   end
 

--- a/test/test_area.rb
+++ b/test/test_area.rb
@@ -21,7 +21,7 @@ class TestGruffArea < GruffTestCase
       4 => '6/4',
       5 => '6/12',
       6 => '6/21',
-      7 => '6/28',
+      7 => '6/28'
     }
   end
 
@@ -32,7 +32,7 @@ class TestGruffArea < GruffTestCase
       0 => '5/6',
       2 => '5/15',
       4 => '5/24',
-      6 => '5/30',
+      6 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -49,7 +49,7 @@ class TestGruffArea < GruffTestCase
       0 => '5/6',
       2 => '5/15',
       4 => '5/24',
-      6 => '5/30',
+      6 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -66,7 +66,7 @@ class TestGruffArea < GruffTestCase
       0 => 'June',
       10 => 'July',
       30 => 'August',
-      50 => 'September',
+      50 => 'September'
     }
     g.data('many points', (0..50).map { |i| rand(100) })
 

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -53,7 +53,7 @@ class TestGruffBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:Art, [0, 5, 8, 15], '#990000')
     g.data(:Philosophy, [10, 3, 2, 8], '#009900')
@@ -71,7 +71,7 @@ class TestGruffBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -183,7 +183,7 @@ class TestGruffBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:apples, [-1, 0, 4, -4])
     g.data(:peaches, [10, 8, 6, 3])
@@ -198,7 +198,7 @@ class TestGruffBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:apples, [1, 2, 3, 4])
     g.data(:peaches, [4, 3, 2, 1])
@@ -221,7 +221,7 @@ class TestGruffBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.y_axis_increment = increment
     g.data(:apples, [1, 0.2, 0.5, 0.7])
@@ -237,7 +237,7 @@ class TestGruffBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
 
     g.data(:apples, [1, 5, 8, 4])
@@ -276,7 +276,7 @@ class TestGruffBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:vancouver, [1, 2, 3, 4])
     g.data(:seattle, [2, 4, 6, 8])
@@ -291,7 +291,7 @@ class TestGruffBar < GruffTestCase
     g.title = 'Background gradient top to bottom'
     g.theme = {
       background_colors: %w[#ff0000 #00ff00],
-      background_direction: :top_bottom,
+      background_direction: :top_bottom
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -306,7 +306,7 @@ class TestGruffBar < GruffTestCase
     g.title = 'Background gradient top to bottom'
     g.theme = {
       background_colors: %w[#ff0000 #00ff00],
-      background_direction: :bottom_top,
+      background_direction: :bottom_top
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -321,7 +321,7 @@ class TestGruffBar < GruffTestCase
     g.title = 'Background gradient left to right'
     g.theme = {
       background_colors: %w[#ff0000 #00ff00],
-      background_direction: :left_right,
+      background_direction: :left_right
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -336,7 +336,7 @@ class TestGruffBar < GruffTestCase
     g.title = 'Background gradient right to left'
     g.theme = {
       background_colors: %w[#ff0000 #00ff00],
-      background_direction: :right_left,
+      background_direction: :right_left
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -351,7 +351,7 @@ class TestGruffBar < GruffTestCase
     g.title = 'Background gradient top left to bottom right'
     g.theme = {
       background_colors: %w[#ff0000 #00ff00],
-      background_direction: :topleft_bottomright,
+      background_direction: :topleft_bottomright
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -367,7 +367,7 @@ class TestGruffBar < GruffTestCase
     g.title_font_size = 30
     g.theme = {
       background_colors: %w[#ff0000 #00ff00],
-      background_direction: :topright_bottomleft,
+      background_direction: :topright_bottomleft
     }
     g.labels = @labels
     @datasets.each do |name, values|
@@ -476,7 +476,7 @@ protected
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -12,7 +12,7 @@ class TestGruffBase < GruffTestCase
       4 => 4,
       5 => 12,
       6 => 21,
-      7 => 28,
+      7 => 28
     }
   end
 

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -26,7 +26,7 @@ class TestGruffDot < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:Art, [0, 5, 8, 15], '#990000')
     g.data(:Philosophy, [10, 3, 2, 8], '#009900')
@@ -146,7 +146,7 @@ class TestGruffDot < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:apples, [-1, 0, 4, -4])
     g.data(:peaches, [10, 8, 6, 3])
@@ -161,7 +161,7 @@ class TestGruffDot < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:apples, [1, 2, 3, 4])
     g.data(:peaches, [4, 3, 2, 1])
@@ -184,7 +184,7 @@ class TestGruffDot < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.y_axis_increment = increment
     g.data(:apples, [1, 0.2, 0.5, 0.7])
@@ -209,7 +209,7 @@ class TestGruffDot < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:vancouver, [1, 2, 3, 4])
     g.data(:seattle, [2, 4, 6, 8])
@@ -240,7 +240,7 @@ protected
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])

--- a/test/test_legend.rb
+++ b/test/test_legend.rb
@@ -22,7 +22,7 @@ class TestGruffLegend < GruffTestCase
       4 => '6/4',
       5 => '6/12',
       6 => '6/21',
-      7 => '6/28',
+      7 => '6/28'
     }
   end
 

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -17,7 +17,7 @@ class TestGruffLine < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:apples, [-1, 0, 4, -4])
     g.data(:peaches, [10, 8, 6, 3])
@@ -195,7 +195,7 @@ class TestGruffLine < GruffTestCase
       0 => 'June',
       10 => 'July',
       30 => 'August',
-      50 => 'September',
+      50 => 'September'
     }
     g.data('many points', (0..50).map { |i| rand(100) })
     g.x_axis_label = 'Months'
@@ -211,7 +211,7 @@ class TestGruffLine < GruffTestCase
       0 => 'June',
       10 => 'July',
       30 => 'August',
-      50 => 'September',
+      50 => 'September'
     }
     g.dot_style = :square
     g.data('many points', (0..50).map { |i| rand(100) })
@@ -674,7 +674,7 @@ private
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:apples, [-1, 0, 4, -4])
     g.data(:peaches, [10, 8, 6, 3])
@@ -688,7 +688,7 @@ private
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     g.data(:apples, [-1, -5, -20, -4])
     g.data(:peaches, [-10, -8, -6, -3])

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -22,7 +22,7 @@ class TestGruffNet < GruffTestCase
       4 => '6/4',
       5 => '6/12',
       6 => '6/21',
-      7 => '6/28',
+      7 => '6/28'
     }
   end
 
@@ -92,7 +92,7 @@ class TestGruffNet < GruffTestCase
       0 => 'June',
       10 => 'July',
       30 => 'August',
-      50 => 'September',
+      50 => 'September'
     }
     g.data('many points', (0..50).map { |i| rand(100) })
 

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -26,7 +26,7 @@ class TestGruffSideStackedBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -41,7 +41,7 @@ class TestGruffSideStackedBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -62,7 +62,7 @@ class TestGruffSideStackedBar < GruffTestCase
       0 => 'September',
       1 => 'Oct',
       2 => 'Nov',
-      3 => 'Dec',
+      3 => 'Dec'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -77,7 +77,7 @@ class TestGruffSideStackedBar < GruffTestCase
       0 => 'September',
       1 => 'Oct',
       2 => 'Nov',
-      3 => 'Dec',
+      3 => 'Dec'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])

--- a/test/test_stacked_area.rb
+++ b/test/test_stacked_area.rb
@@ -23,7 +23,7 @@ class TestGruffStackedArea < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -38,7 +38,7 @@ class TestGruffStackedArea < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])

--- a/test/test_stacked_bar.rb
+++ b/test/test_stacked_bar.rb
@@ -23,7 +23,7 @@ class TestGruffStackedBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -38,7 +38,7 @@ class TestGruffStackedBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])
@@ -54,7 +54,7 @@ class TestGruffStackedBar < GruffTestCase
       0 => '5/6',
       1 => '5/15',
       2 => '5/24',
-      3 => '5/30',
+      3 => '5/30'
     }
     @datasets.each do |data|
       g.data(data[0], data[1])


### PR DESCRIPTION
$ bundle exec rubocop --only Style/TrailingCommaInHashLiteral --auto-correct