### PR TITLE
Rubocop: Use literal instead of new method

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -337,19 +337,6 @@ Style/EmptyElse:
   Exclude:
     - 'lib/gruff/line.rb'
 
-# Offense count: 12
-# Cop supports --auto-correct.
-Style/EmptyLiteral:
-  Exclude:
-    - 'lib/gruff/area.rb'
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/bezier.rb'
-    - 'lib/gruff/line.rb'
-    - 'lib/gruff/photo_bar.rb'
-    - 'lib/gruff/side_stacked_bar.rb'
-    - 'lib/gruff/stacked_area.rb'
-    - 'test/test_line.rb'
-
 # Offense count: 3
 Style/EvalWithLocation:
   Exclude:

--- a/lib/gruff/area.rb
+++ b/lib/gruff/area.rb
@@ -15,7 +15,7 @@ class Gruff::Area < Gruff::Base
     @d = @d.stroke 'transparent'
 
     @norm_data.each do |data_row|
-      poly_points = Array.new
+      poly_points = []
       @d = @d.fill data_row.color
 
       data_row.points.each_with_index do |data_point, index|

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -237,13 +237,13 @@ module Gruff
       # Internal for calculations
       @raw_columns = 800.0
       @raw_rows = 800.0 * (@rows / @columns)
-      @data = Array.new
+      @data = []
       @marker_count = nil
       @maximum_value = @minimum_value = nil
       @increment = nil
-      @labels = Hash.new
+      @labels = {}
       @label_formatting = nil
-      @labels_seen = Hash.new
+      @labels_seen = {}
       @sort = false
       @sorted_drawing = false
       @title = nil

--- a/lib/gruff/bezier.rb
+++ b/lib/gruff/bezier.rb
@@ -9,7 +9,7 @@ class Gruff::Bezier < Gruff::Base
     @x_increment = @graph_width / (column_count - 1).to_f
 
     @norm_data.each do |data_row|
-      poly_points = Array.new
+      poly_points = []
       @d = @d.fill data_row.color
 
       data_row[1].each_with_index do |data_point, index|

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -45,7 +45,7 @@ class Gruff::Line < Gruff::Base
 
   # Set a value for a baseline reference line..
   def baseline_value=(new_value)
-    @reference_lines[:baseline] ||= Hash.new
+    @reference_lines[:baseline] ||= {}
     @reference_lines[:baseline][:value] = new_value
   end
 
@@ -58,7 +58,7 @@ class Gruff::Line < Gruff::Base
   end
 
   def baseline_color=(new_value)
-    @reference_lines[:baseline] ||= Hash.new
+    @reference_lines[:baseline] ||= {}
     @reference_lines[:baseline][:color] = new_value
   end
 
@@ -80,7 +80,7 @@ class Gruff::Line < Gruff::Base
       super args.shift
     end
 
-    @reference_lines = Hash.new
+    @reference_lines = {}
     @reference_line_default_color = 'red'
     @reference_line_default_width = 5
 

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -82,7 +82,7 @@ protected
   # Sets up colors with a list of images that will be used.
   # Images should be 340px tall
   def init_photo_bar_graphics
-    color_list = Array.new
+    color_list = []
     theme_dir = File.dirname(__FILE__) + '/../../assets/' + theme
 
     Dir.open(theme_dir).each do |file|

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -34,7 +34,7 @@ protected
     length = Array.new(column_count, @graph_left)
     padding = (@bar_width * (1 - @bar_spacing)) / 2
     if @show_labels_for_bar_values
-      label_values = Array.new
+      label_values = []
       0.upto(column_count - 1) { |i| label_values[i] = { value: 0, right_x: 0 } }
     end
     @norm_data.each_with_index do |data_row, row_index|

--- a/lib/gruff/stacked_area.rb
+++ b/lib/gruff/stacked_area.rb
@@ -20,7 +20,7 @@ class Gruff::StackedArea < Gruff::Base
     iterator = last_series_goes_on_bottom ? :reverse_each : :each
     @norm_data.send(iterator) do |data_row|
       prev_data_points = data_points
-      data_points = Array.new
+      data_points = []
 
       @d = @d.fill data_row.color
 

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -492,7 +492,7 @@ class TestGruffLine < GruffTestCase
       g.dataxy(field, data.each_with_index.map { |d, i| [i + 1, d[field]] if d[field] }.compact)
     end
 
-    labels = Hash.new
+    labels = {}
     data.each_with_index do |d, i|
       labels[i + 1] = d[:date] if d.size > 1
     end


### PR DESCRIPTION
$ bundle exec rubocop --only Style/EmptyLiteral --auto-correct