### PR TITLE
Rubocop: Fix style of string interpolation with variable

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -650,12 +650,6 @@ Style/TrivialAccessors:
   Exclude:
     - 'lib/gruff/pie.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/VariableInterpolation:
-  Exclude:
-    - 'test/image_compare.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/ZeroLengthPredicate:

--- a/test/image_compare.rb
+++ b/test/image_compare.rb
@@ -53,7 +53,7 @@ end
 
 if $0 == __FILE__
   unless ARGV.size == 2
-    puts "Usage:  #$0 <image1> <image2>"
+    puts "Usage:  #{$0} <image1> <image2>"
     exit 1
   end
   ImageCompare.compare(ARGV[0], ARGV[1])


### PR DESCRIPTION
bundle exec rubocop --only Style/VariableInterpolation --auto-correct