### PR TITLE
Rubocop: Use symbols as proc when possible

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -613,16 +613,6 @@ Style/StringLiterals:
 Style/SymbolArray:
   EnforcedStyle: brackets
 
-# Offense count: 4
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoredMethods.
-# IgnoredMethods: respond_to, define_method
-Style/SymbolProc:
-  Exclude:
-    - 'lib/gruff/scene.rb'
-    - 'test/test_line.rb'
-    - 'test/test_net.rb'
-
 # Offense count: 13
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, AllowSafeAssignment.

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -54,7 +54,7 @@ class Gruff::Scene < Gruff::Base
 
   def draw
     # Join all the custom paths and filter out the empty ones
-    image_paths = @layers.map { |layer| layer.path }.reject { |path| path.empty? }
+    image_paths = @layers.map(&:path).reject(&:empty?)
     images = Magick::ImageList.new(*image_paths)
     @base_image = images.flatten_images
   end

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -222,7 +222,7 @@ class TestGruffLine < GruffTestCase
   end
 
   def test_similar_high_end_values
-    @dataset = %w[29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828].map { |i| i.to_f }
+    @dataset = %w[29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828].map(&:to_f)
 
     g = Gruff::Line.new
     g.title = 'Similar High End Values Test'

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -103,7 +103,7 @@ class TestGruffNet < GruffTestCase
   def test_similar_high_end_values
     g = Gruff::Net.new
     g.title = "Similar High End Values Test"
-    g.data('similar points', %w[29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828].map { |i| i.to_f })
+    g.data('similar points', %w[29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828].map(&:to_f))
 
     # Default theme
     g.write("test/output/net_similar_high_end_values.png")


### PR DESCRIPTION
$ bundle exec rubocop --only Style/SymbolProc --auto-correct