### PR TITLE
Rubocop: Remove redundant parentheses

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -538,12 +538,6 @@ Style/PreferredHashMethods:
   Exclude:
     - 'lib/gruff/bullet.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Style/RedundantParentheses:
-  Exclude:
-    - 'lib/gruff/side_bar.rb'
-
 # Offense count: 6
 # Cop supports --auto-correct.
 Style/RedundantPercentQ:

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -116,7 +116,7 @@ protected
 
   def draw_label(y_offset, index, label = nil)
     if !@labels[index].nil? && @labels_seen[index].nil?
-      lbl = (@use_data_label) ? label : @labels[index]
+      lbl = @use_data_label ? label : @labels[index]
       @d.fill = @font_color
       @d.font = @font if @font
       @d.stroke = 'transparent'


### PR DESCRIPTION
$ bundle exec rubocop --only Style/RedundantParentheses --auto-correct