### PR TITLE
Rubocop: Use Hash#key? instead of Hash#has_key?

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -515,14 +515,6 @@ Style/PerlBackrefs:
   Exclude:
     - 'lib/gruff/scene.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: short, verbose
-Style/PreferredHashMethods:
-  Exclude:
-    - 'lib/gruff/bullet.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/RedundantSort:

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -66,14 +66,14 @@ class Gruff::Bullet < Gruff::Base
     @d = @d.rectangle(@graph_left, 0, @graph_left + @graph_width, @graph_height)
 
     [:high, :low].each_with_index do |indicator, index|
-      next unless @options.has_key?(indicator)
+      next unless @options.key?(indicator)
 
       @d = @d.fill @colors[index + 1]
       indicator_width_x = @graph_left + @graph_width * (@options[indicator] / @maximum_value)
       @d = @d.rectangle(@graph_left, 0, indicator_width_x, @graph_height)
     end
 
-    if @options.has_key?(:target)
+    if @options.key?(:target)
       @d = @d.fill @font_color
       target_x = @graph_left + @graph_width * (@options[:target] / @maximum_value)
       half_thickness = @thickness / 2.0


### PR DESCRIPTION
$ bundle exec rubocop --only Style/PreferredHashMethods --auto-correct