### PR TITLE
Rubocop: Fix String literal style

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -563,13 +563,6 @@ Style/StringHashKeys:
   Exclude:
     - 'Rakefile'
 
-# Offense count: 209
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle, ConsistentQuotesInMultiline.
-# SupportedStyles: single_quotes, double_quotes
-Style/StringLiterals:
-  Enabled: false
-
 # Offense count: 2
 # Cop supports --auto-correct.
 # Configuration parameters: MinSize.

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -3,7 +3,7 @@ require 'gruff/themes'
 
 # http://en.wikipedia.org/wiki/Bullet_graph
 class Gruff::Bullet < Gruff::Base
-  def initialize(target_width = "400x40")
+  def initialize(target_width = '400x40')
     if not Numeric === target_width
       geometric_width, geometric_height = target_width.split('x')
       @columns = geometric_width.to_f

--- a/lib/gruff/mini/legend.rb
+++ b/lib/gruff/mini/legend.rb
@@ -102,7 +102,7 @@ module Gruff
         while calculate_width(scale_fontsize(@legend_font_size), truncated_label) > (@columns - @legend_left_margin - @right_margin) && (truncated_label.length > 1)
           truncated_label = truncated_label[0..truncated_label.length - 2]
         end
-        truncated_label + (truncated_label.length < label.to_s.length ? "..." : '')
+        truncated_label + (truncated_label.length < label.to_s.length ? '...' : '')
       end
     end
   end

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -1,4 +1,4 @@
-require "observer"
+require 'observer'
 require 'gruff/base'
 
 ##
@@ -190,7 +190,7 @@ private
   end
 
   def select_default
-    @filenames.include?("default.png") ? "default.png" : ''
+    @filenames.include?('default.png') ? 'default.png' : ''
   end
 
   # Returns the string "#{filename}.png", if it exists.

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -75,7 +75,7 @@ protected
     end
     if @show_labels_for_bar_values
       label_values.each_with_index do |data, i|
-        val = (@label_formatting || "%.2f") % data[:value]
+        val = (@label_formatting || '%.2f') % data[:value]
         draw_value_label(data[:right_x] + 40, (@graph_top + (((i + 1) * @bar_width) - (@bar_width / 2))) - 12, val.commify, true)
       end
     end

--- a/test/test_area.rb
+++ b/test/test_area.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffArea < GruffTestCase
   def setup
@@ -11,7 +11,7 @@ class TestGruffArea < GruffTestCase
       [:Julie, [22, 29, 35, 38, 36, 40, 46, 57]],
       [:Jane, [95, 95, 95, 90, 85, 80, 88, 100]],
       [:Philip, [90, 34, 23, 12, 78, 89, 98, 88]],
-      ["Arthur", [5, 10, 13, 11, 6, 16, 22, 32]]
+      ['Arthur', [5, 10, 13, 11, 6, 16, 22, 32]]
     ]
     @sample_labels = {
       0 => '5/6',
@@ -27,7 +27,7 @@ class TestGruffArea < GruffTestCase
 
   def test_area_graph
     g = Gruff::Area.new
-    g.title = "Visual Multi-Area Graph Test"
+    g.title = 'Visual Multi-Area Graph Test'
     g.labels = {
       0 => '5/6',
       2 => '5/15',
@@ -39,12 +39,12 @@ class TestGruffArea < GruffTestCase
     end
 
     # Default theme
-    g.write("test/output/area_keynote.png")
+    g.write('test/output/area_keynote.png')
   end
 
   def test_resize
     g = Gruff::Area.new(400)
-    g.title = "Small Size Multi-Area Graph Test"
+    g.title = 'Small Size Multi-Area Graph Test'
     g.labels = {
       0 => '5/6',
       2 => '5/15',
@@ -56,12 +56,12 @@ class TestGruffArea < GruffTestCase
     end
 
     # Default theme
-    g.write("test/output/area_keynote_small.png")
+    g.write('test/output/area_keynote_small.png')
   end
 
   def test_many_datapoints
     g = Gruff::Area.new
-    g.title = "Many Multi-Area Graph Test"
+    g.title = 'Many Multi-Area Graph Test'
     g.labels = {
       0 => 'June',
       10 => 'July',
@@ -71,12 +71,12 @@ class TestGruffArea < GruffTestCase
     g.data('many points', (0..50).map { |i| rand(100) })
 
     # Default theme
-    g.write("test/output/area_many.png")
+    g.write('test/output/area_many.png')
   end
 
   def test_many_areas_graph_small
     g = Gruff::Area.new(400)
-    g.title = "Many Values Area Test 400px"
+    g.title = 'Many Values Area Test 400px'
     g.labels = {
       0 => '5/6',
       10 => '5/15',
@@ -90,12 +90,12 @@ class TestGruffArea < GruffTestCase
     end
 
     # Default theme
-    g.write("test/output/area_many_areas_small.png")
+    g.write('test/output/area_many_areas_small.png')
   end
 
   def test_area_graph_tiny
     g = Gruff::Area.new(300)
-    g.title = "Area Test 300px"
+    g.title = 'Area Test 300px'
     g.labels = {
       0 => '5/6',
       10 => '5/15',
@@ -109,20 +109,20 @@ class TestGruffArea < GruffTestCase
     end
 
     # Default theme
-    g.write("test/output/area_tiny.png")
+    g.write('test/output/area_tiny.png')
   end
 
   def test_wide
     g = setup_basic_graph('800x400')
-    g.title = "Area Wide"
-    g.write("test/output/area_wide.png")
+    g.title = 'Area Wide'
+    g.write('test/output/area_wide.png')
   end
 
 protected
 
   def setup_basic_graph(size = 800)
     g = Gruff::Area.new(size)
-    g.title = "My Graph Title"
+    g.title = 'My Graph Title'
     g.labels = @sample_labels
     @datasets.each do |data|
       g.data(data[0], data[1])

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffBase < GruffTestCase
   def setup

--- a/test/test_bezier.rb
+++ b/test/test_bezier.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestBezier < GruffTestCase
   def setup
@@ -15,22 +15,22 @@ class TestBezier < GruffTestCase
 
   def test_bezier
     g = Gruff::Bezier.new
-    g.title = "Bezier?"
+    g.title = 'Bezier?'
     g.data 'Series 1', [0, 100]
-    g.write("test/output/bezier.png")
+    g.write('test/output/bezier.png')
   end
 
   def test_bezier_2
     g = Gruff::Bezier.new
     g.data 'Series 2', [0, 127, 150]
-    g.write("test/output/bezier_2.png")
+    g.write('test/output/bezier_2.png')
   end
 
   def test_bezier_3
     g = Gruff::Bezier.new
     g.data 'Series 3', [100, 300, 200, 250]
     g.minimum_value = 0
-    g.write("test/output/bezier_3.png")
+    g.write('test/output/bezier_3.png')
   end
 
   def test_bezier_4
@@ -47,6 +47,6 @@ class TestBezier < GruffTestCase
         2.9516386719456804
       ]
     )
-    g.write("test/output/bezier_4.png")
+    g.write('test/output/bezier_4.png')
   end
 end

--- a/test/test_bullet.rb
+++ b/test/test_bullet.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffBullet < GruffTestCase
   def setup
@@ -15,7 +15,7 @@ class TestGruffBullet < GruffTestCase
 
   def test_bullet_graph
     g = Gruff::Bullet.new
-    g.title = "Monthly Revenue"
+    g.title = 'Monthly Revenue'
     g.data(*@data_args)
     g.replace_colors(
       %w[
@@ -33,7 +33,7 @@ class TestGruffBullet < GruffTestCase
         #bae5e5
       ]
     )
-    g.write("test/output/bullet_greyscale.png")
+    g.write('test/output/bullet_greyscale.png')
   end
 
   def test_no_options
@@ -55,6 +55,6 @@ class TestGruffBullet < GruffTestCase
         #bae5e5
       ]
     )
-    g.write("test/output/bullet_no_options.png")
+    g.write('test/output/bullet_no_options.png')
   end
 end

--- a/test/test_labels_for_null_data.rb
+++ b/test/test_labels_for_null_data.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestLabelsForNullData < GruffTestCase
   def setup
@@ -20,6 +20,6 @@ class TestLabelsForNullData < GruffTestCase
     g.data('data', @dataset)
     g.minimum_value = 0
 
-    g.write("test/output/TestLabelsForNullData.png")
+    g.write('test/output/TestLabelsForNullData.png')
   end
 end

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffNet < GruffTestCase
   def setup
@@ -11,7 +11,7 @@ class TestGruffNet < GruffTestCase
       [:Julie, [22, 29, 35, 38, 36, 40, 46, 57]],
       [:Jane, [95, 95, 95, 90, 85, 80, 88, 100]],
       [:Philip, [90, 34, 23, 12, 78, 89, 98, 88]],
-      ["Arthur", [5, 10, 13, 11, 6, 16, 22, 32]]
+      ['Arthur', [5, 10, 13, 11, 6, 16, 22, 32]]
     ]
 
     @sample_labels = {
@@ -33,18 +33,18 @@ class TestGruffNet < GruffTestCase
     ]
 
     g = Gruff::Net.new
-    g.title = "Small Values Net Graph Test"
+    g.title = 'Small Values Net Graph Test'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/net_small.png")
+    g.write('test/output/net_small.png')
 
     g = Gruff::Net.new(400)
-    g.title = "Small Values Net Graph Test 400px"
+    g.title = 'Small Values Net Graph Test 400px'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/net_small_small.png")
+    g.write('test/output/net_small_small.png')
   end
 
   def test_net_starts_with_zero
@@ -54,18 +54,18 @@ class TestGruffNet < GruffTestCase
     ]
 
     g = Gruff::Net.new
-    g.title = "Small Values Net Graph Test"
+    g.title = 'Small Values Net Graph Test'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/net_small_zero.png")
+    g.write('test/output/net_small_zero.png')
 
     g = Gruff::Net.new(400)
-    g.title = "Small Values Net Graph Test 400px"
+    g.title = 'Small Values Net Graph Test 400px'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/net_small_small_zero.png")
+    g.write('test/output/net_small_small_zero.png')
   end
 
   def test_net_large_values
@@ -77,17 +77,17 @@ class TestGruffNet < GruffTestCase
     ]
 
     g = Gruff::Net.new
-    g.title = "Very Large Values Net Graph Test"
+    g.title = 'Very Large Values Net Graph Test'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
-    g.write("test/output/net_large.png")
+    g.write('test/output/net_large.png')
   end
 
   def test_many_datapoints
     g = Gruff::Net.new
-    g.title = "Many Multi-Net Graph Test"
+    g.title = 'Many Multi-Net Graph Test'
     g.labels = {
       0 => 'June',
       10 => 'July',
@@ -97,21 +97,21 @@ class TestGruffNet < GruffTestCase
     g.data('many points', (0..50).map { |i| rand(100) })
 
     # Default theme
-    g.write("test/output/net_many.png")
+    g.write('test/output/net_many.png')
   end
 
   def test_similar_high_end_values
     g = Gruff::Net.new
-    g.title = "Similar High End Values Test"
+    g.title = 'Similar High End Values Test'
     g.data('similar points', %w[29.43 29.459 29.498 29.53 29.548 29.589 29.619 29.66 29.689 29.849 29.878 29.74 29.769 29.79 29.808 29.828].map(&:to_f))
 
     # Default theme
-    g.write("test/output/net_similar_high_end_values.png")
+    g.write('test/output/net_similar_high_end_values.png')
   end
 
   def test_many_nets_graph_small
     g = Gruff::Net.new(400)
-    g.title = "Many Values Net Test 400px"
+    g.title = 'Many Values Net Test 400px'
     g.labels = {
       0 => '5/6',
       10 => '5/15',
@@ -125,12 +125,12 @@ class TestGruffNet < GruffTestCase
     end
 
     # Default theme
-    g.write("test/output/net_many_nets_small.png")
+    g.write('test/output/net_many_nets_small.png')
   end
 
   def test_dots_graph_tiny
     g = Gruff::Net.new(300)
-    g.title = "Dots Test 300px"
+    g.title = 'Dots Test 300px'
     g.labels = {
       0 => '5/6',
       10 => '5/15',
@@ -144,29 +144,29 @@ class TestGruffNet < GruffTestCase
     end
 
     # Default theme
-    g.write("test/output/net_dots_tiny.png")
+    g.write('test/output/net_dots_tiny.png')
   end
 
   def test_no_data
     g = Gruff::Net.new(400)
-    g.title = "No Data"
+    g.title = 'No Data'
     # Default theme
-    g.write("test/output/net_no_data.png")
+    g.write('test/output/net_no_data.png')
 
     g = Gruff::Net.new(400)
-    g.title = "No Data Title"
+    g.title = 'No Data Title'
     g.no_data_message = 'There is no data'
-    g.write("test/output/net_no_data_msg.png")
+    g.write('test/output/net_no_data_msg.png')
   end
 
   def test_all_zeros
     g = Gruff::Net.new(400)
-    g.title = "All Zeros"
+    g.title = 'All Zeros'
 
     g.data(:gus, [0, 0, 0, 0])
 
     # Default theme
-    g.write("test/output/net_no_data_other.png")
+    g.write('test/output/net_no_data_other.png')
   end
 
   def test_no_title
@@ -176,47 +176,47 @@ class TestGruffNet < GruffTestCase
       g.data(data[0], data[1])
     end
 
-    g.write("test/output/net_no_title.png")
+    g.write('test/output/net_no_title.png')
   end
 
   def test_no_net_markers
     g = setup_basic_graph(400)
-    g.title = "No Net Markers"
+    g.title = 'No Net Markers'
     g.hide_line_markers = true
-    g.write("test/output/net_no_net_markers.png")
+    g.write('test/output/net_no_net_markers.png')
   end
 
   def test_no_legend
     g = setup_basic_graph(400)
-    g.title = "No Legend"
+    g.title = 'No Legend'
     g.hide_legend = true
-    g.write("test/output/net_no_legend.png")
+    g.write('test/output/net_no_legend.png')
   end
 
   def test_nothing_but_the_graph
     g = setup_basic_graph(400)
-    g.title = "THIS TITLE SHOULD NOT DISPLAY!!!"
+    g.title = 'THIS TITLE SHOULD NOT DISPLAY!!!'
     g.hide_line_markers = true
     g.hide_legend = true
     g.hide_title = true
-    g.write("test/output/net_nothing_but_the_graph.png")
+    g.write('test/output/net_nothing_but_the_graph.png')
   end
 
   def test_wide_graph
     g = setup_basic_graph('800x400')
-    g.title = "Wide Graph"
-    g.write("test/output/net_wide_graph.png")
+    g.title = 'Wide Graph'
+    g.write('test/output/net_wide_graph.png')
 
     g = setup_basic_graph('400x200')
-    g.title = "Wide Graph Small"
-    g.write("test/output/net_wide_graph_small.png")
+    g.title = 'Wide Graph Small'
+    g.write('test/output/net_wide_graph_small.png')
   end
 
 protected
 
   def setup_basic_graph(size = 800)
     g = Gruff::Net.new(size)
-    g.title = "My Graph Title"
+    g.title = 'My Graph Title'
     g.labels = @sample_labels
     @datasets.each do |data|
       g.data(data[0], data[1])

--- a/test/test_photo.rb
+++ b/test/test_photo.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffPhotoBar < GruffTestCase
 #   def setup

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffPie < GruffTestCase
   def setup
@@ -10,115 +10,115 @@ class TestGruffPie < GruffTestCase
       [:Egbert, [22]],
       [:Adam, [95]],
       [:Bill, [90]],
-      ["Frank", [5]],
-      ["Zero", [0]]
+      ['Frank', [5]],
+      ['Zero', [0]]
     ]
   end
 
   def test_pie_graph
     g = Gruff::Pie.new
-    g.title = "Visual Pie Graph Test"
+    g.title = 'Visual Pie Graph Test'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
     # Default theme
-    g.write("test/output/pie_keynote.png")
+    g.write('test/output/pie_keynote.png')
   end
 
   def test_pie_graph_greyscale
     g = Gruff::Pie.new
-    g.title = "Greyscale Pie Graph Test"
+    g.title = 'Greyscale Pie Graph Test'
     g.theme = Gruff::Themes::GREYSCALE
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
     # Default theme
-    g.write("test/output/pie_grey.png")
+    g.write('test/output/pie_grey.png')
   end
 
   def test_pie_graph_pastel
     g = Gruff::Pie.new
     g.theme = Gruff::Themes::PASTEL
-    g.title = "Pastel Pie Graph Test"
+    g.title = 'Pastel Pie Graph Test'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
     # Default theme
-    g.write("test/output/pie_pastel.png")
+    g.write('test/output/pie_pastel.png')
   end
 
   def test_pie_graph_small
     g = Gruff::Pie.new(400)
-    g.title = "Visual Pie Graph Test Small"
+    g.title = 'Visual Pie Graph Test Small'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
     # Default theme
-    g.write("test/output/pie_keynote_small.png")
+    g.write('test/output/pie_keynote_small.png')
   end
 
   def test_pie_graph_nearly_equal
     g = Gruff::Pie.new
-    g.title = "Pie Graph Nearly Equal"
+    g.title = 'Pie Graph Nearly Equal'
 
     g.data(:Blake, [41])
     g.data(:Aaron, [42])
 #    g.data(:Grouch, [40])
 #    g.data(:Snuffleupagus, [43])
 
-    g.write("test/output/pie_nearly_equal.png")
+    g.write('test/output/pie_nearly_equal.png')
   end
 
   def test_pie_graph_equal
     g = Gruff::Pie.new
-    g.title = "Pie Graph Equal"
+    g.title = 'Pie Graph Equal'
 
     g.data(:Bert, [41])
     g.data(:Adam, [41])
 
-    g.write("test/output/pie_equal.png")
+    g.write('test/output/pie_equal.png')
   end
 
   def test_pie_graph_zero
     g = Gruff::Pie.new
-    g.title = "Pie Graph One Zero"
+    g.title = 'Pie Graph One Zero'
 
     g.data(:Bert, [0])
     g.data(:Adam, [1])
 
-    g.write("test/output/pie_zero.png")
+    g.write('test/output/pie_zero.png')
   end
 
   def test_pie_graph_one_val
     g = Gruff::Pie.new
-    g.title = "Pie Graph One Val"
+    g.title = 'Pie Graph One Val'
 
     g.data(:Bert, 53)
     g.data(:Adam, 29)
 
-    g.write("test/output/pie_one_val.png")
+    g.write('test/output/pie_one_val.png')
   end
 
   def test_wide
     g = setup_basic_graph('800x400')
-    g.title = "Wide Pie"
-    g.write("test/output/pie_wide.png")
+    g.title = 'Wide Pie'
+    g.write('test/output/pie_wide.png')
   end
 
   def test_label_size
     g = setup_basic_graph()
-    g.title = "Pie With Small Legend"
+    g.title = 'Pie With Small Legend'
     g.legend_font_size = 10
-    g.write("test/output/pie_legend.png")
+    g.write('test/output/pie_legend.png')
 
     g = setup_basic_graph(400)
-    g.title = "Small Pie With Small Legend"
+    g.title = 'Small Pie With Small Legend'
     g.legend_font_size = 10
-    g.write("test/output/pie_legend_small.png")
+    g.write('test/output/pie_legend_small.png')
   end
 
   def test_tiny_simple_pie
@@ -133,19 +133,19 @@ class TestGruffPie < GruffTestCase
     g.marker_font_size = 40.0
     g.minimum_value = 0.0
 
-    write_test_file g, "pie_simple.png"
+    write_test_file g, 'pie_simple.png'
   end
 
   def test_pie_with_adjusted_text_offset_percentage
     g = setup_basic_graph
-    g.title = "Adjusted Text Offset Percentage"
+    g.title = 'Adjusted Text Offset Percentage'
     g.text_offset_percentage = 0.03
-    g.write "test/output/pie_adjusted_text_offset_percentage.png"
+    g.write 'test/output/pie_adjusted_text_offset_percentage.png'
   end
 
   def test_subclassed_pie_with_custom_labels
     CustomLabeledPie.new(800).tap do |graph|
-      graph.title = "Subclassed Pie with Custom Lables"
+      graph.title = 'Subclassed Pie with Custom Lables'
 
       @datasets.map { |set| set << set.join(': ') }.each do |data|
         graph.data(data[0], data[1], label: data[2])
@@ -159,7 +159,7 @@ protected
 
   def setup_basic_graph(size = 800)
     g = Gruff::Pie.new(size)
-    g.title = "My Graph Title"
+    g.title = 'My Graph Title'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end

--- a/test/test_scene.rb
+++ b/test/test_scene.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 require 'yaml'
 
 class LayerStub < Gruff::Layer; attr_reader :base_dir, :filenames, :selected_filename; end
@@ -8,71 +8,71 @@ class LayerStub < Gruff::Layer; attr_reader :base_dir, :filenames, :selected_fil
 class TestGruffScene < GruffTestCase
   def test_hazy
     g = setup_scene
-    g.weather = "cloudy"
+    g.weather = 'cloudy'
     g.haze = true
     g.time = Time.mktime(2006, 7, 4, 4, 35)
-    g.write "test/output/scene_hazy_night.png"
+    g.write 'test/output/scene_hazy_night.png'
   end
 
   def test_stormy_night
     g = setup_scene
-    g.weather = "stormy"
+    g.weather = 'stormy'
     g.time = Time.mktime(2006, 7, 4, 0, 0)
-    g.write "test/output/scene_stormy_night.png"
+    g.write 'test/output/scene_stormy_night.png'
   end
 
   def test_not_hazy
     g = setup_scene
-    g.weather = "cloudy"
+    g.weather = 'cloudy'
     g.haze = false
     g.time = Time.mktime(2006, 7, 4, 6, 00)
-    g.write "test/output/scene_not_hazy_day.png"
+    g.write 'test/output/scene_not_hazy_day.png'
   end
 
   def test_partly_cloudy
     g = setup_scene
-    g.weather = "partly cloudy"
+    g.weather = 'partly cloudy'
     g.haze = false
     g.time = Time.mktime(2006, 7, 4, 13, 00)
-    g.write "test/output/scene_partly_cloudy_day.png"
+    g.write 'test/output/scene_partly_cloudy_day.png'
   end
 
   def test_stormy_day
     g = setup_scene
-    g.weather = "stormy"
+    g.weather = 'stormy'
     g.haze = false
     g.time = Time.mktime(2006, 7, 4, 8, 00)
-    g.write "test/output/scene_stormy_day.png"
+    g.write 'test/output/scene_stormy_day.png'
   end
 
   def test_layer
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "clouds")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'clouds')
     assert_equal %w[cloudy.png partly_cloudy.png stormy.png], l.filenames.sort
 
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "grass")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'grass')
     assert_equal 'default.png', l.selected_filename
 
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "sky")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'sky')
     l.update Time.mktime(2006, 7, 4, 12, 35) # 12:35, July 4, 2006
     assert_equal '1200.png', l.selected_filename
 
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "sky")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'sky')
     l.update Time.mktime(2006, 7, 4, 0, 0) # 00:00, July 4, 2006
     assert_equal '0000.png', l.selected_filename
 
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "sky")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'sky')
     l.update Time.mktime(2006, 7, 4, 23, 35) # 23:35, July 4, 2006
     assert_equal '2000.png', l.selected_filename
 
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "sky")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'sky')
     l.update Time.mktime(2006, 7, 4, 0, 1) # 00:01, July 4, 2006
     assert_equal '0000.png', l.selected_filename
 
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "sky")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'sky')
     l.update Time.mktime(2006, 7, 4, 2, 0) # 02:00, July 4, 2006
     assert_equal '0200.png', l.selected_filename
 
-    l = LayerStub.new(File.expand_path("../assets/city_scene", File.dirname(__FILE__)), "sky")
+    l = LayerStub.new(File.expand_path('../assets/city_scene', File.dirname(__FILE__)), 'sky')
     l.update Time.mktime(2006, 7, 4, 4, 00) # 04:00, July 4, 2006
     assert_equal '0400.png', l.selected_filename
 
@@ -86,7 +86,7 @@ class TestGruffScene < GruffTestCase
 private
 
   def setup_scene
-    g = Gruff::Scene.new("500x100", File.expand_path("../assets/city_scene", File.dirname(__FILE__)))
+    g = Gruff::Scene.new('500x100', File.expand_path('../assets/city_scene', File.dirname(__FILE__)))
     g.layers = %w[background haze sky clouds]
     g.weather_group = %w[clouds]
     g.time_group = %w[background sky]

--- a/test/test_side_bar.rb
+++ b/test/test_side_bar.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffSideBar < GruffTestCase
   def test_bar_graph
@@ -9,18 +9,18 @@ class TestGruffSideBar < GruffTestCase
   def test_bar_spacing
     g = setup_basic_graph(Gruff::SideBar, 800)
     g.bar_spacing = 0
-    g.title = "100% spacing between bars"
-    g.write("test/output/side_bar_spacing_full.png")
+    g.title = '100% spacing between bars'
+    g.write('test/output/side_bar_spacing_full.png')
 
     g = setup_basic_graph(Gruff::SideBar, 800)
     g.bar_spacing = 0.5
-    g.title = "50% spacing between bars"
-    g.write("test/output/side_bar_spacing_half.png")
+    g.title = '50% spacing between bars'
+    g.write('test/output/side_bar_spacing_half.png')
 
     g = setup_basic_graph(Gruff::SideBar, 800)
     g.bar_spacing = 1
-    g.title = "0% spacing between bars"
-    g.write("test/output/side_bar_spacing_none.png")
+    g.title = '0% spacing between bars'
+    g.write('test/output/side_bar_spacing_none.png')
   end
 
   def test_x_axis_range
@@ -28,25 +28,25 @@ class TestGruffSideBar < GruffTestCase
     g.title = 'Should run from 8 to 32'
     g.hide_line_numbers = false
     g.theme_37signals
-    g.data("Grapes", [8])
-    g.data("Apples", [24])
-    g.data("Oranges", [32])
-    g.data("Watermelon", [8])
-    g.data("Peaches", [12])
+    g.data('Grapes', [8])
+    g.data('Apples', [24])
+    g.data('Oranges', [32])
+    g.data('Watermelon', [8])
+    g.data('Peaches', [12])
     g.labels = { 0 => '2003', 2 => '2004', 4 => '2005' }
-    g.write("test/output/side_bar_data_range.png")
+    g.write('test/output/side_bar_data_range.png')
   end
 
   def test_bar_labels
     g = Gruff::SideBar.new('400x300')
     g.title = 'Should show labels for each bar'
-    g.data("Grapes", [8])
-    g.data("Apples", [24])
-    g.data("Oranges", [32])
-    g.data("Watermelon", [8])
-    g.data("Peaches", [12])
+    g.data('Grapes', [8])
+    g.data('Apples', [24])
+    g.data('Oranges', [32])
+    g.data('Watermelon', [8])
+    g.data('Peaches', [12])
     g.labels = { 0 => '2003', 2 => '2004', 4 => '2005' }
     g.show_labels_for_bar_values = true
-    g.write("test/output/side_bar_labels.png")
+    g.write('test/output/side_bar_labels.png')
   end
 end

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffSideStackedBar < GruffTestCase
   def setup
@@ -21,7 +21,7 @@ class TestGruffSideStackedBar < GruffTestCase
 
   def test_bar_graph
     g = Gruff::SideStackedBar.new
-    g.title = "Visual Stacked Bar Graph Test"
+    g.title = 'Visual Stacked Bar Graph Test'
     g.labels = {
       0 => '5/6',
       1 => '5/15',
@@ -31,12 +31,12 @@ class TestGruffSideStackedBar < GruffTestCase
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write "test/output/side_stacked_bar_keynote.png"
+    g.write 'test/output/side_stacked_bar_keynote.png'
   end
 
   def test_bar_graph_small
     g = Gruff::SideStackedBar.new(400)
-    g.title = "Visual Stacked Bar Graph Test"
+    g.title = 'Visual Stacked Bar Graph Test'
     g.labels = {
       0 => '5/6',
       1 => '5/15',
@@ -46,18 +46,18 @@ class TestGruffSideStackedBar < GruffTestCase
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write "test/output/side_stacked_bar_keynote_small.png"
+    g.write 'test/output/side_stacked_bar_keynote_small.png'
   end
 
   def test_wide
     g = setup_basic_graph('800x400')
-    g.title = "Wide SSBar"
-    g.write "test/output/side_stacked_bar_wide.png"
+    g.title = 'Wide SSBar'
+    g.write 'test/output/side_stacked_bar_wide.png'
   end
 
   def test_should_space_long_left_labels_appropriately
     g = Gruff::SideStackedBar.new
-    g.title = "Stacked Bar Long Label"
+    g.title = 'Stacked Bar Long Label'
     g.labels = {
       0 => 'September',
       1 => 'Oct',
@@ -67,12 +67,12 @@ class TestGruffSideStackedBar < GruffTestCase
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write "test/output/side_stacked_bar_long_label.png"
+    g.write 'test/output/side_stacked_bar_long_label.png'
   end
 
   def test_bar_labels
     g = Gruff::SideStackedBar.new
-    g.title = "Stacked Bar Long Label"
+    g.title = 'Stacked Bar Long Label'
     g.labels = {
       0 => 'September',
       1 => 'Oct',
@@ -83,14 +83,14 @@ class TestGruffSideStackedBar < GruffTestCase
       g.data(data[0], data[1])
     end
     g.show_labels_for_bar_values = true
-    g.write "test/output/side_stacked_bar_labels.png"
+    g.write 'test/output/side_stacked_bar_labels.png'
   end
 
 protected
 
   def setup_basic_graph(size = 800)
     g = Gruff::SideStackedBar.new(size)
-    g.title = "My Graph Title"
+    g.title = 'My Graph Title'
     g.labels = @sample_labels
     @datasets.each do |data|
       g.data(data[0], data[1])

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffSpider < GruffTestCase
   def setup
@@ -10,7 +10,7 @@ class TestGruffSpider < GruffTestCase
       [:Constitution, [12]],
       [:Intelligence, [12]],
       [:Wisdom, [10]],
-      ["Charisma", [16]]
+      ['Charisma', [16]]
     ]
 
 #     @datasets = [
@@ -26,81 +26,81 @@ class TestGruffSpider < GruffTestCase
 
   def test_spider_graph
     g = Gruff::Spider.new(20)
-    g.title = "Spider Graph Test"
+    g.title = 'Spider Graph Test'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
     # Default theme
-    g.write("test/output/spider_keynote.png")
+    g.write('test/output/spider_keynote.png')
   end
 
   def test_pie_graph_small
     g = Gruff::Spider.new(20, 400)
-    g.title = "Visual Spider Graph Test Small"
+    g.title = 'Visual Spider Graph Test Small'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
     # Default theme
-    g.write("test/output/spider_small.png")
+    g.write('test/output/spider_small.png')
   end
 
   def test_spider_graph_nearly_equal
     g = Gruff::Spider.new(50)
-    g.title = "Spider Graph Nearly Equal"
+    g.title = 'Spider Graph Nearly Equal'
 
     g.data(:Blake, [41])
     g.data(:Aaron, [42])
     g.data(:Grouch, [40])
 #    g.data(:Snuffleupagus, [43])
 
-    g.write("test/output/spider_nearly_equal.png")
+    g.write('test/output/spider_nearly_equal.png')
   end
 
   def test_pie_graph_equal
     g = Gruff::Spider.new(50)
-    g.title = "Spider Graph Equal"
+    g.title = 'Spider Graph Equal'
 
     g.data(:Bert, [41])
     g.data(:Adam, [41])
     g.data(:Joe, [41])
 
-    g.write("test/output/spider_equal.png")
+    g.write('test/output/spider_equal.png')
   end
 
   def test_pie_graph_zero
     g = Gruff::Spider.new(2)
-    g.title = "Pie Graph Two One Zero"
+    g.title = 'Pie Graph Two One Zero'
 
     g.data(:Bert, [0])
     g.data(:Adam, [1])
     g.data(:Sam,  [2])
 
-    g.write("test/output/spider_zero.png")
+    g.write('test/output/spider_zero.png')
   end
 
   def test_wide
     g = setup_basic_graph('800x400')
-    g.title = "Wide spider"
-    g.write("test/output/spider_wide.png")
+    g.title = 'Wide spider'
+    g.write('test/output/spider_wide.png')
   end
 
   def test_label_size
     g = setup_basic_graph()
-    g.title = "Spider With Small Legend"
+    g.title = 'Spider With Small Legend'
     g.legend_font_size = 10
-    g.write("test/output/spider_legend.png")
+    g.write('test/output/spider_legend.png')
 
     g = setup_basic_graph(400)
-    g.title = "Small spider With Small Legend"
+    g.title = 'Small spider With Small Legend'
     g.legend_font_size = 10
-    g.write("test/output/spider_legend_small.png")
+    g.write('test/output/spider_legend_small.png')
   end
 
   def test_theme_37signals
     g = Gruff::Spider.new(20)
-    g.title = "Spider Graph Test"
+    g.title = 'Spider Graph Test'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
@@ -108,51 +108,51 @@ class TestGruffSpider < GruffTestCase
     g.theme = Gruff::Themes::THIRTYSEVEN_SIGNALS
 
     # Default theme
-    g.write("test/output/spider_37signals.png")
+    g.write('test/output/spider_37signals.png')
   end
 
   def test_no_axes
     g = Gruff::Spider.new(20)
-    g.title = "Look ma, no axes"
+    g.title = 'Look ma, no axes'
     g.hide_axes = true
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/spider_no_axes.png")
+    g.write('test/output/spider_no_axes.png')
   end
 
   def test_no_print
     g = Gruff::Spider.new(20)
-    g.title = "Should not print"
+    g.title = 'Should not print'
     g.hide_text = true
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/spider_no_print.png")
+    g.write('test/output/spider_no_print.png')
   end
 
   def test_transparency
     g = Gruff::Spider.new(20)
-    g.title = "Transparent background"
+    g.title = 'Transparent background'
     g.hide_text = true
     g.transparent_background = true
     g.hide_axes = true
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/spider_no_background.png")
+    g.write('test/output/spider_no_background.png')
   end
 
   def test_overlay
     g = Gruff::Spider.new(20)
-    g.title = "George (blue) vs Sarah (white)"
+    g.title = 'George (blue) vs Sarah (white)'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write("test/output/spider_overlay_1.png")
+    g.write('test/output/spider_overlay_1.png')
 
     g = Gruff::Spider.new(20)
-    g.title = "Transparent background"
+    g.title = 'Transparent background'
     g.hide_text = true
     g.hide_axes = true
     g.transparent_background = true
@@ -162,13 +162,13 @@ class TestGruffSpider < GruffTestCase
       [:Constitution, [18]],
       [:Intelligence, [8]],
       [:Wisdom, [14]],
-      ["Charisma", [4]]
+      ['Charisma', [4]]
     ]
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.marker_color = "#4F6EFF"
-    g.write("test/output/spider_overlay_2.png")
+    g.marker_color = '#4F6EFF'
+    g.write('test/output/spider_overlay_2.png')
   end
 
   def test_lots_of_data
@@ -208,8 +208,8 @@ class TestGruffSpider < GruffTestCase
       ]
     )
 
-    g.title = "Sample Data"
-    g.write("test/output/spider_lots_of_data.png")
+    g.title = 'Sample Data'
+    g.write('test/output/spider_lots_of_data.png')
   end
 
   def test_lots_of_data_with_large_names
@@ -249,26 +249,26 @@ class TestGruffSpider < GruffTestCase
       ]
     )
 
-    g.title = "Zoo Inventory"
-    g.write("test/output/spider_lots_of_data_normal_names.png")
+    g.title = 'Zoo Inventory'
+    g.write('test/output/spider_lots_of_data_normal_names.png')
   end
 
   def test_rotation
     g = Gruff::Spider.new(20)
-    g.title = "Rotation"
+    g.title = 'Rotation'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
 
     g.rotation = 45 # degrees
-    g.write("test/output/spider_rotation.png")
+    g.write('test/output/spider_rotation.png')
   end
 
 protected
 
   def setup_basic_graph(size = 800, max = 20)
     g = Gruff::Spider.new(max, size)
-    g.title = "My Graph Title"
+    g.title = 'My Graph Title'
     @datasets.each do |data|
       g.data(data[0], data[1])
     end

--- a/test/test_stacked_bar.rb
+++ b/test/test_stacked_bar.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/ruby
 
-require File.dirname(__FILE__) + "/gruff_test_case"
+require File.dirname(__FILE__) + '/gruff_test_case'
 
 class TestGruffStackedBar < GruffTestCase
   def setup
@@ -18,7 +18,7 @@ class TestGruffStackedBar < GruffTestCase
 
   def test_bar_graph
     g = Gruff::StackedBar.new
-    g.title = "Visual Stacked Bar Graph Test"
+    g.title = 'Visual Stacked Bar Graph Test'
     g.labels = {
       0 => '5/6',
       1 => '5/15',
@@ -28,12 +28,12 @@ class TestGruffStackedBar < GruffTestCase
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write "test/output/stacked_bar_keynote.png"
+    g.write 'test/output/stacked_bar_keynote.png'
   end
 
   def test_bar_graph_small
     g = Gruff::StackedBar.new(400)
-    g.title = "Visual Stacked Bar Graph Test"
+    g.title = 'Visual Stacked Bar Graph Test'
     g.labels = {
       0 => '5/6',
       1 => '5/15',
@@ -43,12 +43,12 @@ class TestGruffStackedBar < GruffTestCase
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write "test/output/stacked_bar_keynote_small.png"
+    g.write 'test/output/stacked_bar_keynote_small.png'
   end
 
   def test_bar_graph_segment_spacing
     g = Gruff::StackedBar.new
-    g.title = "Visual Stacked Bar Graph Test"
+    g.title = 'Visual Stacked Bar Graph Test'
     g.segment_spacing = 0
     g.labels = {
       0 => '5/6',
@@ -59,6 +59,6 @@ class TestGruffStackedBar < GruffTestCase
     @datasets.each do |data|
       g.data(data[0], data[1])
     end
-    g.write "test/output/stacked_bar_keynote_no_space.png"
+    g.write 'test/output/stacked_bar_keynote_no_space.png'
   end
 end


### PR DESCRIPTION
$ bundle exec rubocop --only Style/StringLiterals --auto-correct