### PR TITLE
Rubocop: Remove redundant parentheses in method calling without args

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -402,19 +402,6 @@ Style/ImplicitRuntimeError:
 Style/MethodCallWithArgsParentheses:
   Enabled: false
 
-# Offense count: 7
-# Cop supports --auto-correct.
-# Configuration parameters: IgnoredMethods.
-Style/MethodCallWithoutArgsParentheses:
-  Exclude:
-    - 'lib/gruff/bar.rb'
-    - 'lib/gruff/photo_bar.rb'
-    - 'lib/gruff/scatter.rb'
-    - 'test/test_bar.rb'
-    - 'test/test_line.rb'
-    - 'test/test_pie.rb'
-    - 'test/test_spider.rb'
-
 # Offense count: 1
 Style/MethodCalledOnDoEndBlock:
   Exclude:

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -47,7 +47,7 @@ protected
     @d = @d.stroke_opacity 0.0
 
     # Setup the BarConversion Object
-    conversion = Gruff::BarConversion.new()
+    conversion = Gruff::BarConversion.new
     conversion.graph_height = @graph_height
     conversion.graph_top = @graph_top
 

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -28,7 +28,7 @@ class Gruff::PhotoBar < Gruff::Base
 
     return # TODO Remove for further development
 
-    init_photo_bar_graphics()
+    init_photo_bar_graphics
 
     #Draw#define_clip_path()
     #Draw#clip_path(pathname)

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -174,7 +174,7 @@ class Gruff::Scatter < Gruff::Base
     super(name, y_data_points, color)
 
     #append the x data to the last entry that was just added in the @data member
-    last_elem = @data.length() - 1
+    last_elem = @data.length - 1
     @data[last_elem].x_points = x_data_points
 
     if @maximum_x_value.nil? && @minimum_x_value.nil?

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -379,7 +379,7 @@ class TestGruffBar < GruffTestCase
 
   def test_legend_should_not_overlap
     g = Gruff::Bar.new(400)
-    g.theme_37signals()
+    g.theme_37signals
     g.title = 'My Graph'
     g.data('Apples Oranges Watermelon Apples Oranges', [1, 2, 3, 4, 4, 3])
     g.data('Oranges', [4, 8, 7, 9, 8, 9])

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -35,7 +35,7 @@ class TestGruffLine < GruffTestCase
   end
 
   def test_line_graph_with_themes
-    line_graph_with_themes()
+    line_graph_with_themes
     line_graph_with_themes(400)
   end
 

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -110,7 +110,7 @@ class TestGruffPie < GruffTestCase
   end
 
   def test_label_size
-    g = setup_basic_graph()
+    g = setup_basic_graph
     g.title = 'Pie With Small Legend'
     g.legend_font_size = 10
     g.write('test/output/pie_legend.png')

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -87,7 +87,7 @@ class TestGruffSpider < GruffTestCase
   end
 
   def test_label_size
-    g = setup_basic_graph()
+    g = setup_basic_graph
     g.title = 'Spider With Small Legend'
     g.legend_font_size = 10
     g.write('test/output/spider_legend.png')


### PR DESCRIPTION
$ bundle exec rubocop --only Style/MethodCallWithoutArgsParentheses --auto-correct