### PR TITLE
Rubocop: Use && instead of and

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -219,14 +219,6 @@ Style/Alias:
   Exclude:
     - 'test/gruff_test_case.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, conditionals
-Style/AndOr:
-  Exclude:
-    - 'lib/gruff/bar.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -29,7 +29,7 @@ class Gruff::Bar < Gruff::Base
   #
   # Default value is 0.9.
   def spacing_factor=(space_percent)
-    raise ArgumentError, 'spacing_factor must be between 0.00 and 1.00' unless space_percent >= 0 and space_percent <= 1
+    raise ArgumentError, 'spacing_factor must be between 0.00 and 1.00' unless (space_percent >= 0) && (space_percent <= 1)
 
     @spacing_factor = (1 - space_percent)
   end


### PR DESCRIPTION
$ bundle exec rubocop --only Style/AndOr --auto-correct