### PR TITLE
Rubocop: Remove unused arguement

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -103,13 +103,6 @@ Lint/UnusedBlockArgument:
     - 'test/test_pie.rb'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: AllowUnusedKeywordArguments, IgnoreEmptyMethods, IgnoreNotImplementedMethods.
-Lint/UnusedMethodArgument:
-  Exclude:
-    - 'lib/gruff/side_stacked_bar.rb'
-
-# Offense count: 1
 Lint/UselessAssignment:
   Exclude:
     - 'lib/gruff/photo_bar.rb'

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -83,11 +83,11 @@ protected
     @d.draw(@base_image)
   end
 
-  def larger_than_max?(data_point, index = 0)
-    max(data_point, index) > @maximum_value
+  def larger_than_max?(_data_point, index = 0)
+    max(index) > @maximum_value
   end
 
-  def max(data_point, index)
+  def max(index)
     @data.reduce(0) { |sum, item| sum + item.points[index] }
   end
 end


### PR DESCRIPTION
$ bundle exec rubocop --only Lint/UnusedMethodArgument --auto-correct