### PR TITLE
Expand cache memory size to avoid “cache resources exhausted” error in ImageMagick

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -3,6 +3,11 @@ require 'bigdecimal'
 
 require 'gruff/deprecated'
 
+if Magick.respond_to?(:limit_resource)
+  memory_size = Magick.limit_resource(:memory)
+  Magick.limit_resource(:memory, memory_size * 2)
+end
+
 ##
 # = Gruff. Graphs.
 #


### PR DESCRIPTION
Sometimes I get a "cache resources exhausted" error in CI.
To avoid this error, it needs to expand cache memory size.