### PR TITLE
Rubocop: Fix Style/ZeroLengthPredicate

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -479,13 +479,6 @@ Style/TrivialAccessors:
   Exclude:
     - 'lib/gruff/pie.rb'
 
-# Offense count: 2
-# Cop supports --auto-correct.
-Style/ZeroLengthPredicate:
-  Exclude:
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/line.rb'
-
 # Offense count: 365
 # Cop supports --auto-correct.
 # Configuration parameters: AutoCorrect, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -777,7 +777,7 @@ module Gruff
           label_widths.shift
           current_x_offset = center(sum(label_widths.first)) unless label_widths.empty?
           line_height = [@legend_caps_height, legend_square_width].max + legend_margin
-          if label_widths.length > 0
+          unless label_widths.empty?
             # Wrap to next line and shrink available graph dimensions
             current_y_offset += line_height
             @graph_top += line_height

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -126,7 +126,7 @@ class Gruff::Line < Gruff::Base
   #   g.labels = {0 => '2003', 2 => '2004', 4 => '2005', 6 => '2006'}
   #   The 0 => '2003' label will be ignored since it is outside the chart range.
   def dataxy(name, x_data_points = [], y_data_points = [], color = nil)
-    raise ArgumentError, 'x_data_points is nil!' if x_data_points.length == 0
+    raise ArgumentError, 'x_data_points is nil!' if x_data_points.empty?
 
     if x_data_points.all? { |p| p.is_a?(Array) && p.size == 2 }
       y_data_points = x_data_points.map { |p| p[1] }


### PR DESCRIPTION
$ bundle exec rubocop --only Style/ZeroLengthPredicate --auto-correct