### PR TITLE
Rubocop: Add frozen_string_literal

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,12 +15,6 @@ Layout/ClassStructure:
     - 'lib/gruff/line.rb'
     - 'lib/gruff/spider.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-Layout/EmptyLineAfterMagicComment:
-  Exclude:
-    - 'gruff.gemspec'
-
 # Offense count: 11
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, IndentationWidth.
@@ -229,13 +223,6 @@ Style/EvalWithLocation:
 Style/ExpandPathArguments:
   Exclude:
     - 'gruff.gemspec'
-
-# Offense count: 62
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: always, always_true, never
-Style/FrozenStringLiteralComment:
-  Enabled: false
 
 # Offense count: 8
 Style/IdenticalConditionalBranches:

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in gruff.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rake/clean'

--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -1,4 +1,6 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'date'

--- a/init.rb
+++ b/init.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 # For Rails
 require 'gruff'

--- a/lib/gruff.rb
+++ b/lib/gruff.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/version'
 
 # Extra full path added to fix loading errors on some installations.

--- a/lib/gruff/accumulator_bar.rb
+++ b/lib/gruff/accumulator_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 ##

--- a/lib/gruff/area.rb
+++ b/lib/gruff/area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 class Gruff::Area < Gruff::Base

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 require 'gruff/bar_conversion'
 

--- a/lib/gruff/bar_conversion.rb
+++ b/lib/gruff/bar_conversion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # Original Author: David Stokar
 #

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rmagick'
 require 'bigdecimal'
 

--- a/lib/gruff/bezier.rb
+++ b/lib/gruff/bezier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 class Gruff::Bezier < Gruff::Base

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 require 'gruff/themes'
 

--- a/lib/gruff/deprecated.rb
+++ b/lib/gruff/deprecated.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 # A mixin for methods that need to be deleted or have been
 # replaced by cleaner code.

--- a/lib/gruff/dot.rb
+++ b/lib/gruff/dot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 ##

--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 ##

--- a/lib/gruff/mini/bar.rb
+++ b/lib/gruff/mini/bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 #
 # Makes a small bar graph suitable for display at 200px or even smaller.

--- a/lib/gruff/mini/legend.rb
+++ b/lib/gruff/mini/legend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruff
   module Mini
     module Legend

--- a/lib/gruff/mini/pie.rb
+++ b/lib/gruff/mini/pie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 #
 # Makes a small pie graph suitable for display at 200px or even smaller.

--- a/lib/gruff/mini/side_bar.rb
+++ b/lib/gruff/mini/side_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ##
 #
 # Makes a small pie graph suitable for display at 200px or even smaller.

--- a/lib/gruff/net.rb
+++ b/lib/gruff/net.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 # Experimental!!! See also the Spider graph.

--- a/lib/gruff/patch/rmagick.rb
+++ b/lib/gruff/patch/rmagick.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Magick
   class Draw
     # Additional method to scale annotation text since Draw.scale doesn't.

--- a/lib/gruff/patch/string.rb
+++ b/lib/gruff/patch/string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class String
   #Taken from http://codesnippets.joyent.com/posts/show/330
   def commify(delimiter = ',')

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 # EXPERIMENTAL!

--- a/lib/gruff/pie.rb
+++ b/lib/gruff/pie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 ##

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 # Here's how to set up an XY Scatter Chart

--- a/lib/gruff/scene.rb
+++ b/lib/gruff/scene.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'observer'
 require 'gruff/base'
 

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 ##

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/side_bar'
 require 'gruff/stacked_mixin'
 

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 
 # Experimental!!! See also the Net graph.

--- a/lib/gruff/stacked_area.rb
+++ b/lib/gruff/stacked_area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 require 'gruff/stacked_mixin'
 

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'gruff/base'
 require 'gruff/stacked_mixin'
 

--- a/lib/gruff/stacked_mixin.rb
+++ b/lib/gruff/stacked_mixin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruff::Base::StackedMixin
   # Used by StackedBar and child classes.
   #

--- a/lib/gruff/store/base_data.rb
+++ b/lib/gruff/store/base_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruff
   class Store
     class BaseData < Struct.new(:label, :points, :color)

--- a/lib/gruff/store/custom_data.rb
+++ b/lib/gruff/store/custom_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruff
   class Store
     class CustomData < Struct.new(:label, :points, :color, :custom)

--- a/lib/gruff/store/xy_data.rb
+++ b/lib/gruff/store/xy_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruff
   class Store
     class XYData < Struct.new(:label, :y_points, :color, :x_points)

--- a/lib/gruff/themes.rb
+++ b/lib/gruff/themes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruff
   module Themes
     # A color scheme similar to the popular presentation software.

--- a/lib/gruff/version.rb
+++ b/lib/gruff/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Gruff
   VERSION = '0.8.0'
 end

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.unshift(File.dirname(__FILE__) + '/../lib/')
 
 RMAGICK_BYPASS_VERSION_TEST = true

--- a/test/support/appearance_assertion.rb
+++ b/test/support/appearance_assertion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'minitest/unit'
 
 module MiniTest

--- a/test/test_accumulator_bar.rb
+++ b/test/test_accumulator_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffAccumulatorBar < GruffTestCase

--- a/test/test_area.rb
+++ b/test/test_area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffArea < GruffTestCase

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffBar < GruffTestCase

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffBase < GruffTestCase

--- a/test/test_bezier.rb
+++ b/test/test_bezier.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestBezier < GruffTestCase

--- a/test/test_bullet.rb
+++ b/test/test_bullet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffBullet < GruffTestCase

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffDot < GruffTestCase

--- a/test/test_labels_for_null_data.rb
+++ b/test/test_labels_for_null_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestLabelsForNullData < GruffTestCase

--- a/test/test_legend.rb
+++ b/test/test_legend.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffLegend < GruffTestCase

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffLine < GruffTestCase

--- a/test/test_mini_bar.rb
+++ b/test/test_mini_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestMiniBar < GruffTestCase

--- a/test/test_mini_pie.rb
+++ b/test/test_mini_pie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestMiniPie < GruffTestCase

--- a/test/test_mini_side_bar.rb
+++ b/test/test_mini_side_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestMiniSideBar < GruffTestCase

--- a/test/test_net.rb
+++ b/test/test_net.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffNet < GruffTestCase

--- a/test/test_photo.rb
+++ b/test/test_photo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffPhotoBar < GruffTestCase

--- a/test/test_pie.rb
+++ b/test/test_pie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffPie < GruffTestCase

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffScatter < Minitest::Test

--- a/test/test_scene.rb
+++ b/test/test_scene.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class LayerStub < Gruff::Layer; attr_reader :base_dir, :filenames, :selected_filename; end

--- a/test/test_side_bar.rb
+++ b/test/test_side_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffSideBar < GruffTestCase

--- a/test/test_sidestacked_bar.rb
+++ b/test/test_sidestacked_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffSideStackedBar < GruffTestCase

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffSpider < GruffTestCase

--- a/test/test_stacked_area.rb
+++ b/test/test_stacked_area.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffStackedArea < GruffTestCase

--- a/test/test_stacked_bar.rb
+++ b/test/test_stacked_bar.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'gruff_test_case'
 
 class TestGruffStackedBar < GruffTestCase


### PR DESCRIPTION
$ bundle exec rubocop --only Style/FrozenStringLiteralComment --auto-correct