### PR TITLE
Rubocop: Fix Style/CommentAnnotation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -174,25 +174,6 @@ Style/CaseEquality:
 Style/ClassAndModuleChildren:
   Enabled: false
 
-# Offense count: 20
-# Cop supports --auto-correct.
-# Configuration parameters: Keywords.
-# Keywords: TODO, FIXME, OPTIMIZE, HACK, REVIEW
-Style/CommentAnnotation:
-  Exclude:
-    - 'lib/gruff/base.rb'
-    - 'lib/gruff/bullet.rb'
-    - 'lib/gruff/deprecated.rb'
-    - 'lib/gruff/dot.rb'
-    - 'lib/gruff/photo_bar.rb'
-    - 'lib/gruff/scatter.rb'
-    - 'lib/gruff/side_bar.rb'
-    - 'test/test_accumulator_bar.rb'
-    - 'test/test_bar.rb'
-    - 'test/test_dot.rb'
-    - 'test/test_line.rb'
-    - 'test/test_scatter.rb'
-
 # Offense count: 8
 Style/CommentedKeyword:
   Exclude:

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -411,7 +411,7 @@ module Gruff
         @minimum_value = data_point if @minimum_value.nil?
         @maximum_value = data_point if @maximum_value.nil?
 
-        # TODO Doesn't work with stacked bar graphs
+        # TODO: Doesn't work with stacked bar graphs
         # Original: @maximum_value = larger_than_max?(data_point, index) ? max(data_point, index) : @maximum_value
         @maximum_value = larger_than_max?(data_point) ? data_point : @maximum_value
         @minimum_value = less_than_min?(data_point) ? data_point : @minimum_value
@@ -593,7 +593,7 @@ module Gruff
         # height to 1.0 and the width to the width of the graph.
         x_axis_label_y_coordinate = @graph_bottom + LABEL_MARGIN * 2 + @marker_caps_height
 
-        # TODO Center between graph area
+        # TODO: Center between graph area
         @d.fill = @font_color
         @d.font = @font if @font
         @d.stroke('transparent')
@@ -942,7 +942,7 @@ module Gruff
     def render_image_background(image_path)
       image = Image.read(image_path)
       if @scale != 1.0
-        image[0].resize!(@scale) # TODO Resize with new scale (crop if necessary for wide graph)
+        image[0].resize!(@scale) # TODO: Resize with new scale (crop if necessary for wide graph)
       end
       image[0]
     end
@@ -1150,7 +1150,7 @@ module Gruff
         end
         @increment = (@spread > 0 && @marker_count > 0) ? significant(@spread / @marker_count) : 1
       else
-        # TODO Make this work for negative values
+        # TODO: Make this work for negative values
         @marker_count = (@spread / @y_axis_increment).to_i
         @increment = @y_axis_increment
       end

--- a/lib/gruff/bullet.rb
+++ b/lib/gruff/bullet.rb
@@ -47,7 +47,7 @@ class Gruff::Bullet < Gruff::Base
   # end
 
   def draw
-    # TODO Left label
+    # TODO: Left label
     # TODO Bottom labels and markers
     # @graph_bottom
     # Calculations are off 800x???

--- a/lib/gruff/deprecated.rb
+++ b/lib/gruff/deprecated.rb
@@ -30,7 +30,7 @@ module Gruff
       @graph_width * @scale
     end
 
-    # TODO Should be calculate_graph_height
+    # TODO: Should be calculate_graph_height
     # def setup_graph_height
     #   @graph_height = @graph_bottom - @graph_top
     # end

--- a/lib/gruff/dot.rb
+++ b/lib/gruff/dot.rb
@@ -75,7 +75,7 @@ protected
         end
         @marker_count ||= 5
       end
-      # TODO Round maximum marker value to a round number like 100, 0.1, 0.5, etc.
+      # TODO: Round maximum marker value to a round number like 100, 0.1, 0.5, etc.
       @increment = (@spread > 0 && @marker_count > 0) ? significant(@spread / @marker_count) : 1
 
       number_of_lines = @marker_count
@@ -93,7 +93,7 @@ protected
         @d.stroke = 'transparent'
         @d.pointsize = scale_fontsize(@marker_font_size)
         @d.gravity = CenterGravity
-        # TODO Center text over line
+        # TODO: Center text over line
         @d = @d.annotate_scaled(@base_image,
                                 0, 0, # Width of box to draw text in
                                 x, @graph_bottom + (LABEL_MARGIN * 2.0), # Coordinates of text

--- a/lib/gruff/photo_bar.rb
+++ b/lib/gruff/photo_bar.rb
@@ -28,7 +28,7 @@ class Gruff::PhotoBar < Gruff::Base
     super
     return unless data_given?
 
-    return # TODO Remove for further development
+    return # TODO: Remove for further development
 
     init_photo_bar_graphics
 

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -79,7 +79,7 @@ class Gruff::Scatter < Gruff::Base
   end
 
   def setup_drawing
-    # TODO Need to get x-axis labels working. Current behavior will be to not allow.
+    # TODO: Need to get x-axis labels working. Current behavior will be to not allow.
     @labels = {}
 
     super
@@ -222,7 +222,7 @@ protected
     @d = @d.stroke_antialias false
 
     if @x_axis_increment.nil?
-      # TODO Do the same for larger numbers...100, 75, 50, 25
+      # TODO: Do the same for larger numbers...100, 75, 50, 25
       if @marker_x_count.nil?
         (3..7).each do |lines|
           if @x_spread % lines == 0.0
@@ -237,7 +237,7 @@ protected
         @x_increment = significant(@x_increment)
       end
     else
-      # TODO Make this work for negative values
+      # TODO: Make this work for negative values
       @maximum_x_value = [@maximum_value.ceil, @x_axis_increment].max
       @minimum_x_value = @minimum_x_value.floor
       calculate_spread
@@ -250,7 +250,7 @@ protected
 
     # Draw vertical line markers and annotate with numbers
     (0..@marker_x_count).each do |index|
-      # TODO Fix the vertical lines, and enable them by default. Not pretty when they don't match up with top y-axis line
+      # TODO: Fix the vertical lines, and enable them by default. Not pretty when they don't match up with top y-axis line
       if @enable_vertical_line_markers
         x = @graph_left + @graph_width - index.to_f * @increment_x_scaled
         @d = @d.stroke(@marker_color)

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -88,7 +88,7 @@ protected
     number_of_lines = @marker_count || 5
     number_of_lines = 1 if number_of_lines == 0
 
-    # TODO Round maximum marker value to a round number like 100, 0.1, 0.5, etc.
+    # TODO: Round maximum marker value to a round number like 100, 0.1, 0.5, etc.
     increment = significant(@spread.to_f / number_of_lines)
     (0..number_of_lines).each do |index|
       line_diff = (@graph_right - @graph_left) / number_of_lines
@@ -103,7 +103,7 @@ protected
         @d.stroke = 'transparent'
         @d.pointsize = scale_fontsize(@marker_font_size)
         @d.gravity = CenterGravity
-        # TODO Center text over line
+        # TODO: Center text over line
         @d = @d.annotate_scaled(@base_image,
                                 0, 0, # Width of box to draw text in
                                 x, @graph_bottom + (LABEL_MARGIN * 2.0), # Coordinates of text

--- a/test/test_accumulator_bar.rb
+++ b/test/test_accumulator_bar.rb
@@ -3,7 +3,7 @@
 require_relative 'gruff_test_case'
 
 class TestGruffAccumulatorBar < GruffTestCase
-  # TODO Delete old output files once when starting tests
+  # TODO: Delete old output files once when starting tests
 
   def setup
     super

--- a/test/test_bar.rb
+++ b/test/test_bar.rb
@@ -3,7 +3,7 @@
 require_relative 'gruff_test_case'
 
 class TestGruffBar < GruffTestCase
-  # TODO Delete old output files once when starting tests
+  # TODO: Delete old output files once when starting tests
 
   def setup
     super

--- a/test/test_dot.rb
+++ b/test/test_dot.rb
@@ -3,7 +3,7 @@
 require_relative 'gruff_test_case'
 
 class TestGruffDot < GruffTestCase
-  # TODO Delete old output files once when starting tests
+  # TODO: Delete old output files once when starting tests
 
   def setup
     @datasets = [

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -668,7 +668,7 @@ class TestGruffLine < GruffTestCase
 
 private
 
-  # TODO Reset data after each theme
+  # TODO: Reset data after each theme
   def line_graph_with_themes(size = nil)
     g = Gruff::Line.new(size)
     g.title = "Multi-Line Graph Test #{size}"

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -186,7 +186,7 @@ class TestGruffScatter < Minitest::Test
     assert_same_image('test/expected/scatter_nothing_but_the_graph.png', 'test/output/scatter_nothing_but_the_graph.png')
   end
 
-  # TODO Implement baselines on x and y axis
+  # TODO: Implement baselines on x and y axis
   #~ def test_baseline_larger_than_data
   #~ g = setup_basic_graph(400)
   #~ g.title = "Baseline Larger Than Data"


### PR DESCRIPTION
$ bundle exec rubocop --only Style/CommentAnnotation --auto-correct