### PR TITLE
Rubocop: Fix Style/RedundantSort

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -248,12 +248,6 @@ Style/NumericPredicate:
     - 'lib/gruff/stacked_bar.rb'
 
 # Offense count: 1
-# Cop supports --auto-correct.
-Style/RedundantSort:
-  Exclude:
-    - 'lib/gruff/base.rb'
-
-# Offense count: 1
 Style/Send:
   Exclude:
     - 'lib/gruff/stacked_area.rb'

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -555,7 +555,7 @@ module Gruff
 
         # Make space for half the width of the rightmost column label.
         # Might be greater than the number of columns if between-style bar markers are used.
-        last_label = @labels.keys.sort.last.to_i
+        last_label = @labels.keys.max.to_i
         extra_room_for_long_label = begin
           (last_label >= (column_count - 1) && @center_labels_over_point) ? calculate_width(@marker_font_size, @labels[last_label]) / 2.0 : 0
         end


### PR DESCRIPTION
$ bundle exec rubocop --only Style/RedundantSort --auto-correct