### PR TITLE
Fix an exception when using an object as an argument that behaves as an Array

### DIFF
--- a/lib/gruff/line.rb
+++ b/lib/gruff/line.rb
@@ -128,6 +128,10 @@ class Gruff::Line < Gruff::Base
   #   g.labels = {0 => '2003', 2 => '2004', 4 => '2005', 6 => '2006'}
   #   The 0 => '2003' label will be ignored since it is outside the chart range.
   def dataxy(name, x_data_points = [], y_data_points = [], color = nil)
+    # make sure it's an array
+    x_data_points = Array(x_data_points)
+    y_data_points = Array(y_data_points)
+
     raise ArgumentError, 'x_data_points is nil!' if x_data_points.empty?
 
     if x_data_points.all? { |p| p.is_a?(Array) && p.size == 2 }
@@ -138,9 +142,8 @@ class Gruff::Line < Gruff::Base
     raise ArgumentError, 'x_data_points.length != y_data_points.length!' if x_data_points.length != y_data_points.length
 
     # call the existing data routine for the y data.
-    data(name, y_data_points, color)
+    store.add(name, y_data_points, color)
 
-    x_data_points = Array(x_data_points) # make sure it's an array
     # append the x data to the last entry that was just added in the @data member
     store.data.last.x_points = x_data_points
 

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -167,6 +167,10 @@ class Gruff::Scatter < Gruff::Base
   # g.data('bitter_melon', [3,5,6], [6,7,8], '#000000')
   #
   def data(name, x_data_points = [], y_data_points = [], color = nil)
+    # make sure it's an array
+    x_data_points = Array(x_data_points)
+    y_data_points = Array(y_data_points)
+
     raise ArgumentError, 'Data Points contain nil Value!' if x_data_points.include?(nil) || y_data_points.include?(nil)
     raise ArgumentError, 'x_data_points is empty!' if x_data_points.empty?
     raise ArgumentError, 'y_data_points is empty!' if y_data_points.empty?

--- a/test/test_line.rb
+++ b/test/test_line.rb
@@ -666,6 +666,18 @@ class TestGruffLine < GruffTestCase
     # assert_match(/no encode delegate for this image format .*\.webp/, $!.message)
   end
 
+  def test_data_duck_typing
+    g = Gruff::Line.new
+
+    obj = Object.new
+    def obj.to_a
+      [1, 2, 3, 4, 5]
+    end
+    g.dataxy('Apples', obj, obj)
+
+    pass
+  end
+
 private
 
   # TODO: Reset data after each theme

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -269,6 +269,18 @@ class TestGruffScatter < Minitest::Test
     assert_same_image('test/expected/scatter_xy.png', 'test/output/scatter_xy.png')
   end
 
+  def test_data_duck_typing
+    g = Gruff::Scatter.new
+
+    obj = Object.new
+    def obj.to_a
+      [1, 2, 3, 4, 5]
+    end
+    g.dataxy('Apples', obj, obj)
+
+    pass
+  end
+
 protected
 
   def setup_basic_graph(size = 800)


### PR DESCRIPTION
### Test code
```ruby
    g = Gruff::Line.new

     obj = Object.new
     def obj.to_a
       [1, 2, 3, 4, 5]
     end

     g.dataxy('Apples', obj, obj)
```

The above code will raise an exception even if the argument object can behave as Array.