### PR TITLE
Rubocop: Fix Style/Alias

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -140,14 +140,6 @@ Security/Eval:
   Exclude:
     - 'test/gruff_test_case.rb'
 
-# Offense count: 1
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: prefer_alias, prefer_alias_method
-Style/Alias:
-  Exclude:
-    - 'test/gruff_test_case.rb'
-
 # Offense count: 3
 # Cop supports --auto-correct.
 # Configuration parameters: EnforcedStyle, ProceduralMethods, FunctionalMethods, IgnoredMethods, AllowBracesOnProceduralOneLiners, BracesRequiredMethods.

--- a/test/gruff_test_case.rb
+++ b/test/gruff_test_case.rb
@@ -17,7 +17,7 @@ require_relative 'support/appearance_assertion'
 Minitest::Reporters.use!
 
 class Gruff::Base
-  alias :write_org :write
+  alias write_org write
 
   def write(filename = 'graph.png')
     basefilename = File.basename(filename).split('.')[0..-2].join('.')


### PR DESCRIPTION
$ bundle exec rubocop --only Style/Alias --auto-correct