### PR TITLE
refactor: Remove duplicated get_maximum_by_stack method

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -1010,25 +1010,6 @@ module Gruff
         @norm_data.sort_by { |a| -a.points.reduce(0) { |sum, num| sum + num.to_f } }
     end
 
-    # Used by StackedBar and child classes.
-    #
-    # May need to be moved to the StackedBar class.
-    def get_maximum_by_stack
-      # Get sum of each stack
-      max_hash = {}
-      store.data.each do |data_set|
-        data_set.points.each_with_index do |data_point, i|
-          max_hash[i] = 0.0 unless max_hash[i]
-          max_hash[i] += data_point.to_f
-        end
-      end
-
-      max_hash.each_key do |key|
-        self.maximum_value = max_hash[key] if max_hash[key] > maximum_value
-      end
-      self.minimum_value = 0
-    end
-
     def make_stacked # :nodoc:
       stacked_values = Array.new(column_count, 0)
       store.data.each do |value_set|


### PR DESCRIPTION
`get_maximum_by_stack` is defined at `Gruff::Base::StackedMixin` too.