### PR TITLE
Test: Use early return instead of skip

### DIFF
--- a/test/support/appearance_assertion.rb
+++ b/test/support/appearance_assertion.rb
@@ -6,8 +6,8 @@ module MiniTest
   module Assertions
     def assert_same_image(expected_image_path, output_image, delta = 0.0)
       # not supported yet
-      skip if RUBY_PLATFORM == 'java'
-      skip if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0')
+      return if RUBY_PLATFORM == 'java'
+      return if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4.0')
 
       expected_path = File.expand_path(expected_image_path)
       expected_image = Magick::Image.read(expected_path).first


### PR DESCRIPTION
Some tests have several assertion.
If use `skip`, subsequent tests are not performed