### PR TITLE
refactor: Avoid using Renderer.instance directly outside Renderer class

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -233,7 +233,6 @@ module Gruff
       @title_font = nil
 
       @scale = @columns / @raw_columns
-      Renderer.instance.scale = @scale
 
       @font = nil
       @bold_title = true


### PR DESCRIPTION
scale value was set up via `setup` method.