### PR TITLE
Fix error of “comparison of Integer with nil failed”

### DIFF
--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -78,13 +78,6 @@ class Gruff::Scatter < Gruff::Base
     @store = Gruff::Store.new(Gruff::Store::XYData)
   end
 
-  def setup_drawing
-    # TODO: Need to get x-axis labels working. Current behavior will be to not allow.
-    @labels = {}
-
-    super
-  end
-
   def draw
     super
     return unless data_given?
@@ -174,18 +167,26 @@ class Gruff::Scatter < Gruff::Base
 
     # Call the existing data routine for the x/y axis data
     store.add(name, y_data_points, color, x_data_points)
-
-    if @maximum_x_value.nil? && @minimum_x_value.nil?
-      @maximum_x_value = @minimum_x_value = x_data_points.first
-    end
-
-    @maximum_x_value = x_data_points.max > @maximum_x_value ? x_data_points.max : @maximum_x_value
-    @minimum_x_value = x_data_points.min < @minimum_x_value ? x_data_points.min : @minimum_x_value
   end
 
   alias dataxy data
 
 protected
+
+  def setup_data
+    # Update the global min/max values for the x data
+    @maximum_x_value ||= store.max_x
+    @minimum_x_value ||= store.min_x
+
+    super
+  end
+
+  def setup_drawing
+    # TODO: Need to get x-axis labels working. Current behavior will be to not allow.
+    @labels = {}
+
+    super
+  end
 
   def calculate_spread #:nodoc:
     super

--- a/test/test_scatter.rb
+++ b/test/test_scatter.rb
@@ -281,6 +281,34 @@ class TestGruffScatter < Minitest::Test
     pass
   end
 
+  def test_minimum_x
+    g = Gruff::Scatter.new
+    g.minimum_x_value = 3
+    g.dataxy('foo', [1, 2, 3, 4, 5], [21, 22, 23, 24, 25])
+    g.dataxy('bar', [6, 7, 8, 9, 10], [26, 27, 28, 29, 30])
+    assert_equal(3, g.minimum_x_value)
+
+    g = Gruff::Scatter.new
+    g.dataxy('foo', [1, 2, 3, 4, 5], [21, 22, 23, 24, 25])
+    g.dataxy('bar', [6, 7, 8, 9, 10], [26, 27, 28, 29, 30])
+    g.minimum_x_value = 3
+    assert_equal(3, g.minimum_x_value)
+  end
+
+  def test_maximum
+    g = Gruff::Scatter.new
+    g.maximum_x_value = 3
+    g.dataxy('foo', [1, 2, 3, 4, 5], [21, 22, 23, 24, 25])
+    g.dataxy('bar', [6, 7, 8, 9, 10], [26, 27, 28, 29, 30])
+    assert_equal(3, g.maximum_x_value)
+
+    g = Gruff::Scatter.new
+    g.dataxy('foo', [1, 2, 3, 4, 5], [21, 22, 23, 24, 25])
+    g.dataxy('bar', [6, 7, 8, 9, 10], [26, 27, 28, 29, 30])
+    g.maximum_x_value = 3
+    assert_equal(3, g.maximum_x_value)
+  end
+
 protected
 
   def setup_basic_graph(size = 800)


### PR DESCRIPTION
It raised an error with setting the minimum_x_value or maximum_value before calling the dataxy() method with Gruff:: Scatter.

Related to #366