### PR TITLE
refactor: Remove stroke_opacity before overriding to get rid of warning message

### DIFF
--- a/lib/gruff/patch/rmagick.rb
+++ b/lib/gruff/patch/rmagick.rb
@@ -13,6 +13,7 @@ module Magick
                text.gsub('%', '%%'))
     end
 
+    remove_method :stroke_opacity
     def stroke_opacity(_opacity)
       raise '#stroke_opacity method has different behavior between RMagick and RMagick4J. Should not use this method.'
     end


### PR DESCRIPTION
This patch will remove following warning message.

```
$ bundle exec rake
/opt/gruff/lib/gruff/patch/rmagick.rb:16: warning: method redefined; discarding old stroke_opacity
```