### PR TITLE
Fix "`get_type_metrics': no text to measure" exception with empty title

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -470,7 +470,7 @@ module Gruff
 
     def setup_graph_measurements
       @marker_caps_height = @hide_line_markers ? 0 : calculate_caps_height(@marker_font_size)
-      @title_caps_height = (@hide_title || @title.nil?) ? 0 : calculate_caps_height(@title_font_size) * @title.lines.to_a.size
+      @title_caps_height = hide_title? ? 0 : calculate_caps_height(@title_font_size) * @title.lines.to_a.size
       @legend_caps_height = @hide_legend ? 0 : calculate_caps_height(@legend_font_size)
 
       if @hide_line_markers
@@ -648,7 +648,7 @@ module Gruff
 
     # Draws a title on the graph.
     def draw_title
-      return if @hide_title || @title.nil?
+      return if hide_title?
 
       font = (@title_font || @font) if @title_font || @font
       font_weight = @bold_title ? Magick::BoldWeight : Magick::NormalWeight
@@ -660,6 +660,10 @@ module Gruff
       end
       text_renderer = Gruff::Renderer::Text.new(@title, font: font, size: font_size, color: @font_color, weight: font_weight)
       text_renderer.render(@raw_columns, 1.0, 0, @top_margin)
+    end
+
+    def hide_title?
+      @hide_title || @title.nil? || @title.empty?
     end
 
     # Draws column labels below graph, centered over x_offset

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -41,6 +41,20 @@ class TestGruffBase < GruffTestCase
     assert_same_image('test/expected/bar_font.png', 'test/output/bar_font.png')
   end
 
+  def test_empty_title
+    g = Gruff::Bar.new
+    g.title = ''
+    g.data('foo', [0, 5, 8, 15])
+    g.draw
+
+    g = Gruff::Bar.new
+    g.title = nil
+    g.data('foo', [0, 5, 8, 15])
+    g.draw
+
+    pass
+  end
+
   def test_title_font_size
     g = Gruff::Bar.new
     g.title = 'Bar Graph With Manual Colors' * 2


### PR DESCRIPTION
### Test code
```ruby
g = Gruff::Bar.new
g.title = ''
g.data 'hoge', [20, 30, 0, 0]
g.write('test.png')
```

### Result
```
$ ruby test.rb
Traceback (most recent call last):
	6: from t.rb:7:in `<main>'
	5: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/gruff-0.9.0/lib/gruff/base.rb:388:in `write'
	4: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/gruff-0.9.0/lib/gruff/bar.rb:35:in `draw'
	3: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/gruff-0.9.0/lib/gruff/base.rb:416:in `draw'
	2: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/gruff-0.9.0/lib/gruff/base.rb:655:in `draw_title'
	1: from /Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/gruff-0.9.0/lib/gruff/renderer/text.rb:39:in `metrics'
/Users/watson/.rbenv/versions/2.7.1/lib/ruby/gems/2.7.0/gems/gruff-0.9.0/lib/gruff/renderer/text.rb:39:in `get_type_metrics': no text to measure (ArgumentError)```