### PR TITLE
refactor Gruff::Base #setup_graph_measurements to reduce complexity

### DIFF
--- a/lib/gruff/renderer/renderer.rb
+++ b/lib/gruff/renderer/renderer.rb
@@ -107,7 +107,7 @@ module Gruff
 
       if @gradated_background_retry_count < 3
         @gradated_background_retry_count += 1
-        gradated_background(top_color, bottom_color, direct)
+        gradated_background(columns, rows, top_color, bottom_color, direct)
       else
         raise e
       end


### PR DESCRIPTION
### Description

Refactored Gruff::Base #setup_graph_measurements to use private methods to calculate each measurement. This moves the intertwined calculations based on hidden aspects of the graph to separate methods to make the decision points easier to follow.

No functional changes were made to the code as part of this PR.

### Related work

Extracted the bulk of this from PR #443.  That PR will be refactored to follow this PR.

It is cleaner to have the refactor in a separate PR to make the follow-on PR easier to understand.  This will also allow for resolution of test failures that are related to the refactor before adding in additional new code changes.