### PR TITLE
Avoid SEGV caused with '%S' in Draw#get_type_metrics by old ImageMagick (6.9.9 or below) 

### DIFF
--- a/lib/gruff/renderer/text.rb
+++ b/lib/gruff/renderer/text.rb
@@ -51,7 +51,14 @@ module Gruff
 
       draw.font_weight = font_weight
       draw.pointsize = size
-      draw.get_type_metrics(image, text.to_s)
+
+      # The old ImageMagick causes SEGV with string which has '%' + alphabet (eg. '%S').
+      # This format is used to embed value into a string using image properties.
+      # However, gruff use plain image as canvas which does not have any property.
+      # So, in here, it just escape % in order to avoid SEGV.
+      text = text.to_s.gsub(/(%+)/) { ('%' * Regexp.last_match(1).size * 2).to_s }
+
+      draw.get_type_metrics(image, text)
     end
   end
 end

--- a/test/test_render_text.rb
+++ b/test/test_render_text.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative 'gruff_test_case'
+
+class TestRenderText < GruffTestCase
+  def test_metrics
+    g = Gruff::Line.new
+    g.data :Jimmy, [25, 36, 86, 39, 25, 31, 79, 88]
+    g.data :Charles, [80, 54, 67, 54, 68, 70, 90, 95]
+    g.title = 'hello %S'
+    g.draw
+
+    pass
+  end
+end


### PR DESCRIPTION
When run following test code with old ImageMagick, it causes SEGV.
This PR will avoid SEGV.

## Code
```
require 'gruff'
g = Gruff::Line.new
g.data :Jimmy, [25, 36, 86, 39, 25, 31, 79, 88]
g.data :Charles, [80, 54, 67, 54, 68, 70, 90, 95]
g.title = 'hello %S'
g.draw
```

## Result
```
$ ruby -e 'require "rmagick"; p Magick::Long_version'
"This is RMagick 4.2.2 ($Date: 2009/12/20 02:33:33 $) Copyright (C) 2009 by Timothy P. Hunter\nBuilt with ImageMagick 6.9.7-10 Q16 x86_64 2021-04-24 http://www.imagemagick.org\nBuilt for ruby 2.7.2\nWeb page: http://rmagick.rubyforge.org\nEmail: rmagick@rubyforge.org\n"
```

```
$ ruby test.rb
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/renderer/text.rb:54: [BUG] Segmentation fault at 0x0000000000000040
ruby 2.7.2p137 (2020-10-01 revision 5445e04352) [x86_64-darwin20]

-- Crash Report log information --------------------------------------------
   See Crash Report log file under the one of following:
     * ~/Library/Logs/DiagnosticReports
     * /Library/Logs/DiagnosticReports
   for more details.
Don't forget to include the above Crash Report log file in bug reports.

-- Control frame information -----------------------------------------------
c:0009 p:---- s:0048 e:000047 CFUNC  :get_type_metrics
c:0008 p:0069 s:0042 e:000041 METHOD /Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/renderer/text.rb:54
c:0007 p:0081 s:0033 e:000032 METHOD /Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:677
c:0006 p:0034 s:0024 e:000023 METHOD /Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:473
c:0005 p:0004 s:0020 e:000019 METHOD /Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/line.rb:172
c:0004 p:0017 s:0016 e:000015 METHOD /Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:437
c:0003 p:0007 s:0012 e:000011 METHOD /Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:419
c:0002 p:0054 s:0007 E:000d08 EVAL   gruff.rb:6 [FINISH]
c:0001 p:0000 s:0003 E:001e10 (none) [FINISH]

-- Ruby level backtrace information ----------------------------------------
gruff.rb:6:in `<main>'
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:419:in `write'
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:437:in `to_image'
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/line.rb:172:in `draw'
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:473:in `draw'
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/base.rb:677:in `draw_title'
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/renderer/text.rb:54:in `metrics'
/Users/watson/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/gruff-0.12.1/lib/gruff/renderer/text.rb:54:in `get_type_metrics'

-- Machine register context ------------------------------------------------
 rax: 0x0000000000000000 rbx: 0x0000000000000000 rcx: 0x0000000000000030
 rdx: 0x000000010aece117 rdi: 0x0000000000000000 rsi: 0x0000000000000000
 rbp: 0x00007ffee69c4530 rsp: 0x00007ffee69c33c0  r8: 0x0000000000000000
  r9: 0x00000001098023e0 r10: 0x0000000000000040 r11: 0x000000000000003d
 r12: 0x0000000000000000 r13: 0x0000000000000000 r14: 0x0000000000000000
 r15: 0x0000000000000000 rip: 0x000000010aece11e rfl: 0x0000000000010207

-- C level backtrace information -------------------------------------------
...
```