### PR TITLE
Update docker files for Apple M1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,14 +1,5 @@
 FROM ubuntu:18.04
 
-RUN apt update && apt install -y gcc libssl-dev libyaml-dev libreadline6-dev zlib1g-dev libncurses5-dev \
-    libmagickwand-dev wget git pkg-config && \
-    wget https://cache.ruby-lang.org/pub/ruby/2.7/ruby-2.7.1.tar.gz && \
-    tar xvzf ruby-2.7.1.tar.gz && \
-    cd ruby-2.7.1 && \
-    ./configure --prefix=/usr --disable-install-rdoc && \
-    make -j install && \
-    cd .. && rm -rf ruby-2.7.1 && \
-    gem install bundler -v 1.17.3 && \
-    /usr/bin/bundle config set --local path 'vendor/bundle'
+RUN apt update && apt install -y gcc git pkg-config ruby ruby-dev libmagickwand-dev
 
 WORKDIR /opt/gruff

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 script_dir=$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)
-docker build -t gruff ${script_dir}
+docker build --platform linux/amd64 -t gruff ${script_dir}

--- a/docker/launch.sh
+++ b/docker/launch.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 prject_dir="$(cd $(dirname ${BASH_SOURCE:-$0}); pwd)/.."
-docker run -v $prject_dir:/opt/gruff --rm -it gruff bash
+docker run --platform linux/amd64 -v $prject_dir:/opt/gruff --rm -it gruff bash


### PR DESCRIPTION
Without `--platform linux/amd64`, seems that `bundle exec rake test` fails with Apple M1.
I guess it related to library compatibility (maybe ImageMagick)