### PR TITLE
Remove redundant argument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -136,13 +136,6 @@ Style/MissingRespondToMissing:
   Exclude:
     - 'lib/gruff/scene.rb'
 
-# Offense count: 1
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: respond_to_missing?
-Style/OptionalBooleanParameter:
-  Exclude:
-    - 'lib/gruff/base.rb'
-
 # Offense count: 2
 # Cop supports --auto-correct.
 Style/StringConcatenation:

--- a/lib/gruff/bar.rb
+++ b/lib/gruff/bar.rb
@@ -119,7 +119,7 @@ private
         if @show_labels_for_bar_values
           bar_value_label = Gruff::BarValueLabel::Bar.new([left_x, left_y, right_x, right_y], store.data[row_index].points[point_index])
           bar_value_label.prepare_rendering(@label_formatting, bar_width) do |x, y, text|
-            draw_value_label(x, y, text, true)
+            draw_value_label(x, y, text)
           end
         end
       end

--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -746,8 +746,8 @@ module Gruff
     end
 
     # Draws the data value over the data point in bar graphs
-    def draw_value_label(x_offset, y_offset, data_point, bar_value = false)
-      return if @hide_line_markers && !bar_value
+    def draw_value_label(x_offset, y_offset, data_point)
+      return if @hide_line_markers
 
       text_renderer = Gruff::Renderer::Text.new(data_point, font: @marker_font)
       text_renderer.add_to_render_queue(1.0, 1.0, x_offset, y_offset)

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -107,7 +107,7 @@ private
         if @show_labels_for_bar_values
           bar_value_label = Gruff::BarValueLabel::SideBar.new([left_x, left_y, right_x, right_y], store.data[row_index].points[point_index])
           bar_value_label.prepare_rendering(@label_formatting, bar_width) do |x, y, text|
-            draw_value_label(x, y, text, true)
+            draw_value_label(x, y, text)
           end
         end
       end

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -115,7 +115,7 @@ private
 
     if @show_labels_for_bar_values
       stack_bar_value_label.prepare_rendering(@label_formatting, bar_width) do |x, y, text|
-        draw_value_label(x, y, text, true)
+        draw_value_label(x, y, text)
       end
     end
   end

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -86,7 +86,7 @@ private
 
     if @show_labels_for_bar_values
       stack_bar_value_label.prepare_rendering(@label_formatting, bar_width) do |x, y, text|
-        draw_value_label(x, y, text, true)
+        draw_value_label(x, y, text)
       end
     end
   end


### PR DESCRIPTION
Because bar_value argument is always given true