### PR TITLE
Fix deprecated in rmagick

### DIFF
--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
     s.platform = 'java'
     s.add_dependency 'rmagick4j'
   else
-    s.add_dependency 'rmagick'
+    s.add_dependency 'rmagick', '>= 4.2'
     s.add_development_dependency 'rubocop', '~> 1.12.1'
     s.add_development_dependency 'rubocop-performance', '~> 1.10.2'
     s.add_development_dependency 'rubocop-rake', '~> 0.5.1'

--- a/lib/gruff/renderer/renderer.rb
+++ b/lib/gruff/renderer/renderer.rb
@@ -44,8 +44,8 @@ module Gruff
 
     # Make a new image at the current size with a solid +color+.
     def solid_background(columns, rows, color)
-      Magick::Image.new(columns, rows) do
-        self.background_color = color
+      Magick::Image.new(columns, rows) do |img|
+        img.background_color = color
       end
     end
 
@@ -97,8 +97,8 @@ module Gruff
 
     # Use with a theme to make a transparent background
     def render_transparent_background(columns, rows)
-      Magick::Image.new(columns, rows) do
-        self.background_color = 'transparent'
+      Magick::Image.new(columns, rows) do |img|
+        img.background_color = 'transparent'
       end
     end
   end


### PR DESCRIPTION
Fix following rmagick deprecated warning.

```
/opt/gruff/lib/gruff/renderer/renderer.rb:47: warning: passing a block without an image argument is deprecated
```