### PR TITLE
Drop Ruby 2.4 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         ref: ${{ github.event.pull_request.head.sha }}
-    - name: Set up Ruby 2.4
+    - name: Set up Ruby 2.5
       uses: ruby/setup-ruby@master
       with:
-        ruby-version: '2.4'
+        ruby-version: '2.5'
         bundler-cache: true
     - name: Install dependencies
       run: bundle install --path=vendor/bundle --jobs 4 --retry 3
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 20
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1']
     name: Ruby ${{ matrix.ruby-version }}
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 
 AllCops:
     EnabledByDefault: true
-    TargetRubyVersion: 2.4
+    TargetRubyVersion: 2.5
     Exclude:
         - 'vendor/bundle/**/*'
         - 'rails_generators/gruff/**/*'

--- a/gruff.gemspec
+++ b/gruff.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rubocop-rake', '~> 0.5.1'
   end
   s.add_dependency 'histogram'
-  s.required_ruby_version = '>= 2.4.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'minitest-reporters'


### PR DESCRIPTION
Ruby 2.4 has a status of End of Life at 2020-03-31

https://www.ruby-lang.org/en/downloads/branches/