### PR TITLE
Raise exception if negative values were given in stacked graph

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -565,7 +565,7 @@ module Gruff
       store.normalize(minimum: minimum_value, spread: @spread)
     end
 
-    def calculate_spread # :nodoc:
+    def calculate_spread
       @spread = maximum_value.to_f - minimum_value.to_f
       @spread = @spread > 0 ? @spread : 1
     end

--- a/lib/gruff/helper/stacked_mixin.rb
+++ b/lib/gruff/helper/stacked_mixin.rb
@@ -16,7 +16,9 @@ module Gruff::Base::StackedMixin
 
     max_hash.each_key do |key|
       self.maximum_value = max_hash[key] if max_hash[key] > maximum_value
+      self.minimum_value = max_hash[key] if max_hash[key] < minimum_value
     end
-    self.minimum_value = 0
+
+    raise "Can't handle negative values in stacked graph" if minimum_value < 0
   end
 end

--- a/lib/gruff/side_stacked_bar.rb
+++ b/lib/gruff/side_stacked_bar.rb
@@ -49,6 +49,7 @@ private
     @show_labels_for_bar_values = false
     @hide_labels = false
     @has_left_labels = true
+    @minimum_value = 0.0
   end
 
   def setup_data

--- a/lib/gruff/stacked_area.rb
+++ b/lib/gruff/stacked_area.rb
@@ -20,6 +20,11 @@ class Gruff::StackedArea < Gruff::Base
 
 private
 
+  def initialize_attributes
+    super
+    @minimum_value = 0.0
+  end
+
   def setup_data
     calculate_maximum_by_stack
     super

--- a/lib/gruff/stacked_bar.rb
+++ b/lib/gruff/stacked_bar.rb
@@ -39,6 +39,7 @@ private
     @label_formatting = nil
     @show_labels_for_bar_values = false
     @hide_labels = false
+    @minimum_value = 0.0
   end
 
   def setup_data


### PR DESCRIPTION
So far, the stacked graphs do not render as expected when dealing with negative values.