### PR TITLE
Raise exception if less data set was given in Gruff::Spider

### DIFF
--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -58,6 +58,12 @@ private
     @graph_height = @graph_bottom - @graph_top
   end
 
+  def setup_data
+    raise(Gruff::IncorrectNumberOfDatasetsException, 'Requires 3 or more data sets') if store.length < 3
+
+    super
+  end
+
   def draw_graph
     # Setup basic positioning
     radius = @graph_height / 2.0

--- a/test/test_spider.rb
+++ b/test/test_spider.rb
@@ -270,6 +270,15 @@ class TestGruffSpider < GruffTestCase
     assert_same_image('test/expected/spider_rotation.png', 'test/output/spider_rotation.png')
   end
 
+  def test_less_many_args
+    assert_raises(Gruff::IncorrectNumberOfDatasetsException) do
+      g = Gruff::Spider.new(20)
+      g.data 'First', [1, 1, 1]
+      g.data 'Two', [1, 1, 1]
+      g.write('test/output/_SHOULD_NOT_ACTUALLY_BE_WRITTEN.png')
+    end
+  end
+
   def test_duck_typing
     g = Gruff::Spider.new(20)
     @datasets.each do |data|


### PR DESCRIPTION
The following error occurs when Polygon cannot be drawn.
Raise an exception appropriately because the error is difficult to understand.

```ruby
require 'gruff'

g = Gruff::Spider.new(10)
g.title = 'Sample Data'
g.data :A, [1, 2]
g.data :B, [5]

g.write("gruff_spider.png")
```

```
/home/watson/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/gruff-0.15.0/lib/gruff/renderer/renderer.rb:19:in `draw': non-conforming drawing primitive definition `polygon' @ error/draw.c/RenderMVGContent/4489 (Magick::ImageMagickError)
        from /home/watson/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/gruff-0.15.0/lib/gruff/renderer/renderer.rb:19:in `finish'
        from /home/watson/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/gruff-0.15.0/lib/gruff/base.rb:465:in `to_image'
        from /home/watson/.rbenv/versions/3.1.2/lib/ruby/gems/3.1.0/gems/gruff-0.15.0/lib/gruff/base.rb:446:in `write'
        from spider.rb:24:in `<main>'
```
