### PR TITLE
Fix deprecation warning for Base#to_blob

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -522,8 +522,8 @@ module Gruff
     # @deprecated Please use +to_image.to_blob+ instead.
     def to_blob(image_format = 'PNG')
       warn '#to_blob is deprecated. Please use `to_image.to_blob` instead'
-      to_image.to_blob do
-        self.format = image_format
+      to_image.to_blob do |image|
+        image.format = image_format
       end
     end
 


### PR DESCRIPTION
```
warning: passing a block without an image argument is deprecated
```

See: https://github.com/rmagick/rmagick/issues/1270