### PR TITLE
Allow to override label margin value

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -27,6 +27,9 @@ module Gruff
 
     DEFAULT_TARGET_WIDTH = 800.0
 
+    # Blank space between graph and labels. Default is +15+.
+    attr_writer :label_margin
+
     # Blank space above the graph. Default is +20+.
     attr_writer :top_margin
 
@@ -180,6 +183,7 @@ module Gruff
       @marker_font = Gruff::Font.new(size: 21.0)
       @legend_font = Gruff::Font.new(size: 20.0)
 
+      @label_margin = LABEL_MARGIN
       @top_margin = @bottom_margin = @left_margin = @right_margin = DEFAULT_MARGIN
       @legend_margin = LEGEND_MARGIN
       @title_margin = TITLE_MARGIN
@@ -646,7 +650,7 @@ module Gruff
         # X Axis
         # Centered vertically and horizontally by setting the
         # height to 1.0 and the width to the width of the graph.
-        x_axis_label_y_coordinate = @graph_bottom + (LABEL_MARGIN * 2) + labels_caps_height
+        x_axis_label_y_coordinate = @graph_bottom + (@label_margin * 2) + labels_caps_height
 
         text_renderer = Gruff::Renderer::Text.new(renderer, @x_axis_label, font: @marker_font)
         text_renderer.add_to_render_queue(@raw_columns, 1.0, 0.0, x_axis_label_y_coordinate)
@@ -674,7 +678,7 @@ module Gruff
           marker_label = (BigDecimal(index.to_s) * BigDecimal(@increment.to_s)) + BigDecimal(minimum_value.to_s)
           label = y_axis_label(marker_label, @increment)
           text_renderer = Gruff::Renderer::Text.new(renderer, label, font: @marker_font)
-          text_renderer.add_to_render_queue(@graph_left - LABEL_MARGIN, 1.0, 0.0, y, Magick::EastGravity)
+          text_renderer.add_to_render_queue(@graph_left - @label_margin, 1.0, 0.0, y, Magick::EastGravity)
         end
       end
     end
@@ -715,7 +719,7 @@ module Gruff
 
       current_y_offset = begin
         if @legend_at_bottom
-          @graph_bottom + @legend_margin + labels_caps_height + LABEL_MARGIN + (@x_axis_label ? (LABEL_MARGIN * 2) + marker_caps_height : 0)
+          @graph_bottom + @legend_margin + labels_caps_height + @label_margin + (@x_axis_label ? (@label_margin * 2) + marker_caps_height : 0)
         else
           hide_title? ? @top_margin + @title_margin : @top_margin + @title_margin + title_caps_height
         end
@@ -771,7 +775,7 @@ module Gruff
       draw_unique_label(index) do
         if x >= @graph_left && x <= @graph_right
           y = @graph_bottom
-          x_offset, y_offset = calculate_label_offset(@marker_font, @labels[index], LABEL_MARGIN, @label_rotation)
+          x_offset, y_offset = calculate_label_offset(@marker_font, @labels[index], @label_margin, @label_rotation)
 
           draw_label_at(1.0, 1.0, x + x_offset, y + y_offset, @labels[index], gravity: gravity, rotation: @label_rotation)
           yield if block
@@ -899,10 +903,10 @@ module Gruff
         if !@has_left_labels && (@hide_line_markers || @hide_line_numbers)
           0.0
         else
-          longest_left_label_width + LABEL_MARGIN
+          longest_left_label_width + @label_margin
         end
       end
-      y_axis_label_width = @y_axis_label.nil? ? 0.0 : marker_caps_height + (LABEL_MARGIN * 2)
+      y_axis_label_width = @y_axis_label.nil? ? 0.0 : marker_caps_height + (@label_margin * 2)
 
       bottom_label_width = extra_left_room_for_long_label
 
@@ -962,10 +966,10 @@ module Gruff
     end
 
     def setup_bottom_margin
-      graph_bottom_margin = hide_bottom_label_area? ? @bottom_margin : @bottom_margin + labels_caps_height + LABEL_MARGIN
+      graph_bottom_margin = hide_bottom_label_area? ? @bottom_margin : @bottom_margin + labels_caps_height + @label_margin
       graph_bottom_margin += (calculate_legend_height + @legend_margin) if @legend_at_bottom
 
-      x_axis_label_height = @x_axis_label.nil? ? 0.0 : marker_caps_height + (LABEL_MARGIN * 2)
+      x_axis_label_height = @x_axis_label.nil? ? 0.0 : marker_caps_height + (@label_margin * 2)
       @raw_rows - graph_bottom_margin - x_axis_label_height
     end
 

--- a/lib/gruff/dot.rb
+++ b/lib/gruff/dot.rb
@@ -59,7 +59,7 @@ private
       unless @hide_line_numbers
         label = y_axis_label(marker_label, @increment)
         text_renderer = Gruff::Renderer::Text.new(renderer, label, font: @marker_font)
-        text_renderer.add_to_render_queue(0, 0, x, @graph_bottom + (LABEL_MARGIN * 1.5), Magick::CenterGravity)
+        text_renderer.add_to_render_queue(0, 0, x, @graph_bottom + (@label_margin * 1.5), Magick::CenterGravity)
       end
     end
   end
@@ -69,7 +69,7 @@ private
 
   def draw_label(y_offset, index)
     draw_unique_label(index) do
-      draw_label_at(@graph_left - LABEL_MARGIN, 1.0, 0.0, y_offset, @labels[index], gravity: Magick::EastGravity)
+      draw_label_at(@graph_left - @label_margin, 1.0, 0.0, y_offset, @labels[index], gravity: Magick::EastGravity)
     end
   end
 end

--- a/lib/gruff/net.rb
+++ b/lib/gruff/net.rb
@@ -112,8 +112,8 @@ private
   def draw_label(center_x, center_y, angle, radius, amount)
     x_offset = center_x # + 15 # The label points need to be tweaked slightly
     y_offset = center_y # + 0  # This one doesn't though
-    x = x_offset + ((radius + LABEL_MARGIN) * Math.sin(deg2rad(angle)))
-    y = y_offset - ((radius + LABEL_MARGIN) * Math.cos(deg2rad(angle)))
+    x = x_offset + ((radius + @label_margin) * Math.sin(deg2rad(angle)))
+    y = y_offset - ((radius + @label_margin) * Math.cos(deg2rad(angle)))
 
     draw_label_at(1.0, 1.0, x, y, amount, gravity: Magick::CenterGravity)
   end

--- a/lib/gruff/scatter.rb
+++ b/lib/gruff/scatter.rb
@@ -188,7 +188,7 @@ private
         label = x_axis_label(marker_label, x_increment)
         x = @graph_left + (increment_x_scaled * index)
         y = @graph_bottom
-        x_offset, y_offset = calculate_label_offset(@marker_font, label, LABEL_MARGIN, @label_rotation)
+        x_offset, y_offset = calculate_label_offset(@marker_font, label, @label_margin, @label_rotation)
 
         draw_label_at(1.0, 1.0, x + x_offset, y + y_offset, label, rotation: @label_rotation)
       end

--- a/lib/gruff/side_bar.rb
+++ b/lib/gruff/side_bar.rb
@@ -90,7 +90,7 @@ private
 
       if minimum_value < 0
         _, metrics = Gruff::BarValueLabel.metrics(minimum_value, @label_formatting, proc_text_metrics)
-        width = metrics.width + LABEL_MARGIN
+        width = metrics.width + @label_margin
         @graph_left += width - @graph_left if width > @graph_left
       end
 
@@ -160,7 +160,7 @@ private
         marker_label = (BigDecimal(diff.abs.to_s) * BigDecimal(increment.to_s)) + BigDecimal(minimum_value.to_s)
         label = x_axis_label(marker_label, @increment)
         text_renderer = Gruff::Renderer::Text.new(renderer, label, font: @marker_font)
-        text_renderer.add_to_render_queue(0, 0, x, @graph_bottom + LABEL_MARGIN, Magick::CenterGravity)
+        text_renderer.add_to_render_queue(0, 0, x, @graph_bottom + @label_margin, Magick::CenterGravity)
       end
     end
   end
@@ -170,7 +170,7 @@ private
 
   def draw_label(y_offset, index)
     draw_unique_label(index) do
-      draw_label_at(@graph_left - LABEL_MARGIN, 1.0, 0.0, y_offset, @labels[index], gravity: Magick::EastGravity)
+      draw_label_at(@graph_left - @label_margin, 1.0, 0.0, y_offset, @labels[index], gravity: Magick::EastGravity)
     end
   end
 

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -54,10 +54,10 @@ private
   def setup_graph_measurements
     super
 
-    @graph_left += LABEL_MARGIN
-    @graph_top += LABEL_MARGIN
-    @graph_right -= LABEL_MARGIN
-    @graph_bottom -= LABEL_MARGIN
+    @graph_left += @label_margin
+    @graph_top += @label_margin
+    @graph_right -= @label_margin
+    @graph_bottom -= @label_margin
 
     @graph_width = @graph_right - @graph_left
     @graph_height = @graph_bottom - @graph_top
@@ -94,7 +94,7 @@ private
     degree = rad2deg(angle)
     metrics = text_metrics(@marker_font, amount)
 
-    r_offset = LABEL_MARGIN # The distance out from the center of the pie to get point
+    r_offset = @label_margin # The distance out from the center of the pie to get point
     x_offset = center_x # The label points need to be tweaked slightly
 
     x_offset -= begin


### PR DESCRIPTION
First thing first: Thank you and congrat's for this gem! Super useful!

# Context

We needed the ability to grow the label margin in a spider chart, in order to have the labels being displayed a bit farther from the chart.

This seems to be dictated by the value of `Gruff::Base::LABEL_MARGIN`, and is not overridable.

I did a dirty temporary hack on my project (replace temporarily the constant value before generating the image, with const_set), but I'd love a cleaner solution

# Solution

Pretty much the same things as for `legend_margin` (for example):
* Add an attr_writer call for label_margin
* Set the value of `@label_margin` to `Gruff::Base::LABEL_MARGIN` in `Gruff::Base#initialize_attributes`
* Replace all other references to `LABEL_MARGIN` by `@label_margin`

Let me know if you see anything that don't work for you in my PR.

Thanks!