### PR TITLE
Add the way to make background transparent

### DIFF
--- a/lib/gruff/base.rb
+++ b/lib/gruff/base.rb
@@ -367,6 +367,14 @@ module Gruff
       @colors = color_list
     end
 
+    # Set whether to make background transparent.
+    #
+    # @param value [Boolean] Specify whether to make background transparent.
+    #
+    def transparent_background=(value)
+      @renderer.transparent_background(@columns, @rows) if value
+    end
+
     # You can set a theme manually. Assign a hash to this method before you
     # send your data.
     #
@@ -378,7 +386,13 @@ module Gruff
     #     background_direction: :top_bottom
     #   }
     #
-    # +background_image: 'squirrel.png'+ is also possible.
+    # +background_colors+
+    # - Array<String> format value - background has gradation. (ex. +background_colors: ['black', 'grey']+)
+    # - String value - background has solid color. (ex. +background_colors: 'orange'+)
+    # - nil - background has transparent. (ex. +background_colors: nil+)
+    #
+    # +background_image+:
+    # - Specify the path to image file when it draw the image as background.
     #
     # +background_direction+ accepts one of following parameters.
     # - +:top_bottom+
@@ -400,7 +414,7 @@ module Gruff
         marker_color: 'white',
         marker_shadow_color: nil,
         font_color: 'black',
-        background_colors: nil,
+        background_colors: 'gray',
         background_image: nil
       }
       @theme_options = defaults.merge options

--- a/lib/gruff/renderer/renderer.rb
+++ b/lib/gruff/renderer/renderer.rb
@@ -24,13 +24,15 @@ module Gruff
     end
 
     def background(columns, rows, scale, theme_options)
+      return image_background(scale, *theme_options[:background_image]) if theme_options[:background_image]
+
       case theme_options[:background_colors]
       when Array
         gradated_background(columns, rows, *theme_options[:background_colors][0..1], theme_options[:background_direction])
       when String
         solid_background(columns, rows, theme_options[:background_colors])
       else
-        image_background(scale, *theme_options[:background_image])
+        transparent_background(columns, rows)
       end
     end
 

--- a/lib/gruff/spider.rb
+++ b/lib/gruff/spider.rb
@@ -24,10 +24,6 @@ class Gruff::Spider < Gruff::Base
     @max_value = max_value
   end
 
-  def transparent_background=(value)
-    renderer.transparent_background(@columns, @rows) if value
-  end
-
   def hide_text=(value)
     @hide_title = @hide_text = value
   end


### PR DESCRIPTION
Fix https://github.com/topfunky/gruff/issues/630

This patch provides two ways to make the background transparent.

## 1. `#transparent_background=`
```ruby
g = Gruff::Bar.new
g.transparent_background = true # use transparent
g.title = 'Hello world'
g.data :Art, [0, 5, 8, 15]
g.data :Philosophy, [10, 3, 2, 8]
g.data :Science, [2, 15, 8, 11]

g.write('bar.png')
```

## 2. Make background to transparent by theme
```ruby
g = Gruff::Bar.new
g.theme = {
  colors: [
    '#FDD84E',
    '#6886B4',
    '#72AE6E',
    '#D1695E',
    '#8A6EAF',
    '#EFAA43',
    'white'
  ],
  marker_color: 'white',
  font_color: 'white',
  background_colors: nil # use transparent
}
g.title = 'Hello world'
g.data :Art, [0, 5, 8, 15]
g.data :Philosophy, [10, 3, 2, 8]
g.data :Science, [2, 15, 8, 11]

g.write('bar.png')
```